### PR TITLE
Enable Google OAuth login

### DIFF
--- a/multinet/settings.py
+++ b/multinet/settings.py
@@ -28,6 +28,7 @@ class MultinetMixin(ConfigMixin):
         configuration.INSTALLED_APPS += [
             's3_file_field',
             'guardian',
+            'allauth.socialaccount.providers.google',
         ]
 
         configuration.AUTHENTICATION_BACKENDS += ['guardian.backends.ObjectPermissionBackend']


### PR DESCRIPTION
This is the only thing required in terms of backend code changes to get Google OAuth supported.

It also currently requires configuration of the social app via the django admin console. However, it could also be done directly through settings if we prefer it that way. It really depends on our preferred deployment method, which I'm not sure even exists yet. For now, it can be configured manually.

Let me know where I should document the process of configuration.