### PR TITLE
Add tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
             DJANGO_MINIO_STORAGE_ENDPOINT: localhost:9000
             DJANGO_MINIO_STORAGE_ACCESS_KEY: minioAccessKey
             DJANGO_MINIO_STORAGE_SECRET_KEY: minioSecretKey
-            DJANGO_MULTINET_ARANGO_URL: http://arangodb:8529
+            DJANGO_MULTINET_ARANGO_URL: http://localhost:8529
             DJANGO_MULTINET_ARANGO_PASSWORD: letmein
 workflows:
   version: 2

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -16,6 +16,7 @@ services:
       - postgres
       - rabbitmq
       - minio
+      - arangodb
 
   celery:
     build:
@@ -37,3 +38,4 @@ services:
       - postgres
       - rabbitmq
       - minio
+      - arangodb

--- a/multinet/api/models/network.py
+++ b/multinet/api/models/network.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import List
 
 from arango.cursor import Cursor
-from arango.database import StandardDatabase
 from arango.graph import Graph
 from django.db import models
 from django_extensions.db.models import TimeStampedModel
@@ -28,12 +27,11 @@ class Network(TimeStampedModel):
         )
 
     def nodes(self, limit: int = 0, offset: int = 0) -> Cursor:
-        db: StandardDatabase = self.workspace.get_arango_db()
-        query = ArangoQuery.from_collections(db, self.node_tables()).paginate(
-            limit=limit, offset=offset
+        return (
+            ArangoQuery.from_collections(self.workspace.get_arango_db(), self.node_tables())
+            .paginate(limit=limit, offset=offset)
+            .execute()
         )
-
-        return db.aql.execute(query=query.query_str, bind_vars=query.bind_vars)
 
     @property
     def edge_count(self) -> int:
@@ -44,12 +42,11 @@ class Network(TimeStampedModel):
         )
 
     def edges(self, limit: int = 0, offset: int = 0) -> Cursor:
-        db: StandardDatabase = self.workspace.get_arango_db()
-        query = ArangoQuery.from_collections(db, self.edge_tables()).paginate(
-            limit=limit, offset=offset
+        return (
+            ArangoQuery.from_collections(self.workspace.get_arango_db(), self.edge_tables())
+            .paginate(limit=limit, offset=offset)
+            .execute()
         )
-
-        return db.aql.execute(query=query.query_str, bind_vars=query.bind_vars)
 
     def get_arango_graph(self) -> Graph:
         workspace: Workspace = self.workspace

--- a/multinet/api/tests/conftest.py
+++ b/multinet/api/tests/conftest.py
@@ -1,7 +1,10 @@
+from django.contrib.auth.models import User
+from guardian.shortcuts import assign_perm
 import pytest
 from pytest_factoryboy import register
 from rest_framework.test import APIClient
 
+from multinet.api.models.workspace import Workspace
 from multinet.api.utils.arango import arango_system_db
 
 from .factories import NetworkFactory, TableFactory, UserFactory, WorkspaceFactory
@@ -13,10 +16,18 @@ def api_client() -> APIClient:
 
 
 @pytest.fixture
-def authenticated_api_client(user) -> APIClient:
+def authenticated_api_client(user: User) -> APIClient:
     client = APIClient()
     client.force_authenticate(user=user)
     return client
+
+
+@pytest.fixture
+def owned_workspace(user: User, workspace: Workspace) -> Workspace:
+    """Return a workspace with the `user` fixture as an owner."""
+    assign_perm('owner', user, workspace)
+
+    return workspace
 
 
 def pytest_configure():

--- a/multinet/api/tests/conftest.py
+++ b/multinet/api/tests/conftest.py
@@ -2,7 +2,9 @@ import pytest
 from pytest_factoryboy import register
 from rest_framework.test import APIClient
 
-from .factories import UserFactory
+from multinet.api.utils.arango import arango_system_db
+
+from .factories import NetworkFactory, TableFactory, UserFactory, WorkspaceFactory
 
 
 @pytest.fixture
@@ -17,4 +19,22 @@ def authenticated_api_client(user) -> APIClient:
     return client
 
 
+def pytest_configure():
+    # Register which databases exist before the function is run.
+    pytest.before_session_arango_databases = set(arango_system_db().databases())
+
+
+def pytest_sessionfinish(session, exitstatus):
+    # Remove any databases created since the session start. This is needed because pytest's
+    # `pytest.mark.django_db` decorator doesn't run the model save/delete methods, meaning the sync
+    # between arangodb and django doesn't happen.
+
+    for db in arango_system_db().databases():
+        if db not in pytest.before_session_arango_databases:
+            arango_system_db().delete_database(db, ignore_missing=True)
+
+
 register(UserFactory)
+register(WorkspaceFactory)
+register(NetworkFactory)
+register(TableFactory)

--- a/multinet/api/tests/conftest.py
+++ b/multinet/api/tests/conftest.py
@@ -8,6 +8,7 @@ from pytest_factoryboy import register
 from rest_framework.test import APIClient
 
 from multinet.api.models import Network, Table, Workspace
+from multinet.api.tests.utils import generate_arango_documents
 from multinet.api.utils.arango import arango_system_db
 
 from .factories import NetworkFactory, TableFactory, UserFactory, WorkspaceFactory
@@ -35,7 +36,7 @@ def owned_workspace(user: User, workspace: Workspace) -> Workspace:
 
 @pytest.fixture
 def populated_node_table(owned_workspace: Workspace) -> Table:
-    nodes = [{'foo': 'bar'}, {'foo2': 'bar2'}, {'foo3': 'bar3'}]
+    nodes = generate_arango_documents(5)
     table, created = Table.objects.get_or_create(
         name=Faker().pystr(), edge=False, workspace=owned_workspace
     )

--- a/multinet/api/tests/conftest.py
+++ b/multinet/api/tests/conftest.py
@@ -36,26 +36,17 @@ def owned_workspace(user: User, workspace: Workspace) -> Workspace:
 
 @pytest.fixture
 def populated_node_table(owned_workspace: Workspace) -> Table:
+    table: Table = Table.objects.create(name=Faker().pystr(), edge=False, workspace=owned_workspace)
+
     nodes = generate_arango_documents(5)
-    table, created = Table.objects.get_or_create(
-        name=Faker().pystr(), edge=False, workspace=owned_workspace
-    )
-
-    if created:
-        table.save()
-
     table.put_rows(nodes)
+
     return table
 
 
 @pytest.fixture
 def populated_edge_table(owned_workspace: Workspace, populated_node_table: Table) -> Table:
-    table, created = Table.objects.get_or_create(
-        name=Faker().pystr(), edge=True, workspace=owned_workspace
-    )
-
-    if created:
-        table.save()
+    table: Table = Table.objects.create(name=Faker().pystr(), edge=True, workspace=owned_workspace)
 
     nodes = list(populated_node_table.get_rows())
     edges = [{'_from': a['_id'], '_to': b['_id']} for a, b in itertools.combinations(nodes, 2)]
@@ -81,14 +72,7 @@ def populated_network(owned_workspace: Workspace, populated_edge_table: Table) -
         ],
     )
 
-    network, created = Network.objects.get_or_create(
-        name=network_name,
-        workspace=owned_workspace,
-    )
-
-    if created:
-        network.save()
-
+    network: Network = Network.objects.create(name=network_name, workspace=owned_workspace)
     return network
 
 

--- a/multinet/api/tests/factories.py
+++ b/multinet/api/tests/factories.py
@@ -30,9 +30,23 @@ class NetworkFactory(factory.django.DjangoModelFactory):
     workspace = factory.SubFactory(WorkspaceFactory)
 
 
-class TableFactory(factory.django.DjangoModelFactory):
+class EdgeTableFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Table
 
     name = factory.fuzzy.FuzzyText()
     workspace = factory.SubFactory(WorkspaceFactory)
+    edge = True
+
+
+class NodeTableFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Table
+
+    name = factory.fuzzy.FuzzyText()
+    workspace = factory.SubFactory(WorkspaceFactory)
+
+
+# Default table to node table
+class TableFactory(NodeTableFactory):
+    pass

--- a/multinet/api/tests/factories.py
+++ b/multinet/api/tests/factories.py
@@ -1,5 +1,8 @@
 from django.contrib.auth.models import User
-import factory.django
+import factory
+import factory.fuzzy
+
+from multinet.api.models import Network, Table, Workspace
 
 
 class UserFactory(factory.django.DjangoModelFactory):
@@ -10,3 +13,26 @@ class UserFactory(factory.django.DjangoModelFactory):
     email = factory.Faker('safe_email')
     first_name = factory.Faker('first_name')
     last_name = factory.Faker('last_name')
+
+
+class WorkspaceFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Workspace
+
+    name = factory.fuzzy.FuzzyText()
+
+
+class NetworkFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Network
+
+    name = factory.fuzzy.FuzzyText()
+    workspace = factory.SubFactory(WorkspaceFactory)
+
+
+class TableFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Table
+
+    name = factory.fuzzy.FuzzyText()
+    workspace = factory.SubFactory(WorkspaceFactory)

--- a/multinet/api/tests/fuzzy.py
+++ b/multinet/api/tests/fuzzy.py
@@ -1,0 +1,24 @@
+import re
+
+
+class Re:
+    def __init__(self, pattern):
+        if isinstance(pattern, type(re.compile(''))):
+            self.pattern = pattern
+        else:
+            self.pattern = re.compile(pattern)
+
+    def __eq__(self, other):
+        return self.pattern.fullmatch(str(other)) is not None
+
+    def __str__(self):
+        return self.pattern.pattern
+
+    def __repr__(self):
+        return repr(self.pattern.pattern)
+
+
+INTEGER_ID_RE = Re(r'\d')
+TIMESTAMP_RE = Re(r'\d{4}-\d{2}-\d{2}T\d{2}\:\d{2}\:\d{2}\.\d{6}Z')
+HTTP_URL_RE = Re(r'http[s]?\://[^/]+(/[^/]+)*[/]?(&.+)?')
+UUID_RE = Re(r'[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}')

--- a/multinet/api/tests/fuzzy.py
+++ b/multinet/api/tests/fuzzy.py
@@ -1,4 +1,5 @@
 import re
+from typing import Dict
 
 
 class Re:
@@ -22,3 +23,17 @@ INTEGER_ID_RE = Re(r'\d')
 TIMESTAMP_RE = Re(r'\d{4}-\d{2}-\d{2}T\d{2}\:\d{2}\:\d{2}\.\d{6}Z')
 HTTP_URL_RE = Re(r'http[s]?\://[^/]+(/[^/]+)*[/]?(&.+)?')
 UUID_RE = Re(r'[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}')
+
+ARANGO_COLL = Re(r'[A-Za-z][-\w]{1,255}')
+ARANGO_DOC_KEY = Re(r'[-\w:\.@()+,=;$!*\'%]{1,254}')
+ARANGO_DOC_ID = Re(str(ARANGO_COLL) + r'\/' + str(ARANGO_DOC_KEY))
+ARANGO_DOC_REV = Re(r'[-\w]+')
+
+
+def dict_to_fuzzy_arango_doc(d: Dict):
+    return {
+        **d,
+        '_id': ARANGO_DOC_ID,
+        '_key': ARANGO_DOC_KEY,
+        '_rev': ARANGO_DOC_REV,
+    }

--- a/multinet/api/tests/fuzzy.py
+++ b/multinet/api/tests/fuzzy.py
@@ -27,7 +27,7 @@ UUID_RE = Re(r'[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}')
 ARANGO_COLL = Re(r'[A-Za-z][-\w]{1,255}')
 ARANGO_DOC_KEY = Re(r'[-\w:\.@()+,=;$!*\'%]{1,254}')
 ARANGO_DOC_ID = Re(str(ARANGO_COLL) + r'\/' + str(ARANGO_DOC_KEY))
-ARANGO_DOC_REV = Re(r'[-\w]+')
+ARANGO_DOC_REV = Re(r'[-_\w]+')
 
 
 def dict_to_fuzzy_arango_doc(d: Dict):
@@ -35,5 +35,12 @@ def dict_to_fuzzy_arango_doc(d: Dict):
         **d,
         '_id': ARANGO_DOC_ID,
         '_key': ARANGO_DOC_KEY,
+        '_rev': ARANGO_DOC_REV,
+    }
+
+
+def arango_doc_to_fuzzy_rev(d: Dict):
+    return {
+        **d,
         '_rev': ARANGO_DOC_REV,
     }

--- a/multinet/api/tests/fuzzy.py
+++ b/multinet/api/tests/fuzzy.py
@@ -19,7 +19,7 @@ class Re:
         return repr(self.pattern.pattern)
 
 
-INTEGER_ID_RE = Re(r'\d')
+INTEGER_ID_RE = Re(r'\d+')
 TIMESTAMP_RE = Re(r'\d{4}-\d{2}-\d{2}T\d{2}\:\d{2}\:\d{2}\.\d{6}Z')
 HTTP_URL_RE = Re(r'http[s]?\://[^/]+(/[^/]+)*[/]?(&.+)?')
 UUID_RE = Re(r'[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}')

--- a/multinet/api/tests/test_network.py
+++ b/multinet/api/tests/test_network.py
@@ -2,6 +2,7 @@ import pytest
 from rest_framework.test import APIClient
 
 from multinet.api.models import Network, Table, Workspace
+from multinet.api.tests.utils import assert_limit_offset_results
 
 from .fuzzy import INTEGER_ID_RE, TIMESTAMP_RE
 
@@ -86,16 +87,13 @@ def test_network_rest_retrieve_nodes(
     populated_network: Network, authenticated_api_client: APIClient
 ):
     workspace: Workspace = populated_network.workspace
-    r = authenticated_api_client.get(
-        f'/api/workspaces/{workspace.name}/networks/{populated_network.name}/nodes/'
-    )
+    nodes = list(populated_network.nodes())
 
-    assert r.json() == {
-        'count': populated_network.node_count,
-        'next': None,
-        'previous': None,
-        'results': list(populated_network.nodes()),
-    }
+    assert_limit_offset_results(
+        authenticated_api_client,
+        f'/api/workspaces/{workspace.name}/networks/{populated_network.name}/nodes/',
+        nodes,
+    )
 
 
 @pytest.mark.django_db
@@ -103,13 +101,10 @@ def test_network_rest_retrieve_edges(
     populated_network: Network, authenticated_api_client: APIClient
 ):
     workspace: Workspace = populated_network.workspace
-    r = authenticated_api_client.get(
-        f'/api/workspaces/{workspace.name}/networks/{populated_network.name}/edges/'
-    )
+    edges = list(populated_network.edges())
 
-    assert r.json() == {
-        'count': populated_network.edge_count,
-        'next': None,
-        'previous': None,
-        'results': list(populated_network.edges()),
-    }
+    assert_limit_offset_results(
+        authenticated_api_client,
+        f'/api/workspaces/{workspace.name}/networks/{populated_network.name}/edges/',
+        edges,
+    )

--- a/multinet/api/tests/test_network.py
+++ b/multinet/api/tests/test_network.py
@@ -1,0 +1,115 @@
+import pytest
+from rest_framework.test import APIClient
+
+from multinet.api.models import Network, Table, Workspace
+
+from .fuzzy import INTEGER_ID_RE, TIMESTAMP_RE
+
+
+@pytest.mark.django_db
+def test_network_rest_create(
+    owned_workspace: Workspace,
+    populated_edge_table: Table,
+    populated_node_table: Table,
+    authenticated_api_client: APIClient,
+):
+    network_name = 'network'
+    r = authenticated_api_client.post(
+        f'/api/workspaces/{owned_workspace.name}/networks/',
+        {'name': network_name, 'edge_table': populated_edge_table.name},
+        format='json',
+    )
+
+    assert r.json() == {
+        'name': network_name,
+        'node_count': len(populated_node_table.get_rows()),
+        'edge_count': len(populated_edge_table.get_rows()),
+        'id': INTEGER_ID_RE,
+        'created': TIMESTAMP_RE,
+        'modified': TIMESTAMP_RE,
+        'workspace': {
+            'id': owned_workspace.pk,
+            'name': owned_workspace.name,
+            'created': TIMESTAMP_RE,
+            'modified': TIMESTAMP_RE,
+            'arango_db_name': owned_workspace.arango_db_name,
+        },
+    }
+
+    # Django will raise an exception if this fails, implicitly validating that the object exists
+    network: Network = Network.objects.get(name=network_name)
+
+    # Assert that object was created in arango
+    assert owned_workspace.get_arango_db().has_graph(network.name)
+
+
+@pytest.mark.django_db
+def test_network_rest_retrieve(populated_network: Network, authenticated_api_client: APIClient):
+    workspace = populated_network.workspace
+
+    assert authenticated_api_client.get(
+        f'/api/workspaces/{workspace.name}/networks/{populated_network.name}/'
+    ).data == {
+        'id': populated_network.pk,
+        'name': populated_network.name,
+        'node_count': populated_network.node_count,
+        'edge_count': populated_network.edge_count,
+        'created': TIMESTAMP_RE,
+        'modified': TIMESTAMP_RE,
+        'workspace': {
+            'id': workspace.pk,
+            'name': workspace.name,
+            'created': TIMESTAMP_RE,
+            'modified': TIMESTAMP_RE,
+            'arango_db_name': workspace.arango_db_name,
+        },
+    }
+
+
+@pytest.mark.django_db
+def test_network_rest_delete(populated_network: Network, authenticated_api_client: APIClient):
+    workspace: Workspace = populated_network.workspace
+
+    r = authenticated_api_client.delete(
+        f'/api/workspaces/{workspace.name}/networks/{populated_network.name}/'
+    )
+
+    assert r.status_code == 204
+
+    # Assert relevant objects are deleted
+    assert Network.objects.filter(name=workspace.name).first() is None
+    assert not workspace.get_arango_db().has_graph(populated_network.name)
+
+
+@pytest.mark.django_db
+def test_network_rest_retrieve_nodes(
+    populated_network: Network, authenticated_api_client: APIClient
+):
+    workspace: Workspace = populated_network.workspace
+    r = authenticated_api_client.get(
+        f'/api/workspaces/{workspace.name}/networks/{populated_network.name}/nodes/'
+    )
+
+    assert r.json() == {
+        'count': populated_network.node_count,
+        'next': None,
+        'previous': None,
+        'results': list(populated_network.nodes()),
+    }
+
+
+@pytest.mark.django_db
+def test_network_rest_retrieve_edges(
+    populated_network: Network, authenticated_api_client: APIClient
+):
+    workspace: Workspace = populated_network.workspace
+    r = authenticated_api_client.get(
+        f'/api/workspaces/{workspace.name}/networks/{populated_network.name}/edges/'
+    )
+
+    assert r.json() == {
+        'count': populated_network.edge_count,
+        'next': None,
+        'previous': None,
+        'results': list(populated_network.edges()),
+    }

--- a/multinet/api/tests/test_network.py
+++ b/multinet/api/tests/test_network.py
@@ -102,7 +102,7 @@ def test_network_rest_delete(populated_network: Network, authenticated_api_clien
     assert r.status_code == 204
 
     # Assert relevant objects are deleted
-    assert Network.objects.filter(name=workspace.name).first() is None
+    assert not Network.objects.filter(name=workspace.name).exists()
     assert not workspace.get_arango_db().has_graph(populated_network.name)
 
 
@@ -115,7 +115,7 @@ def test_network_rest_delete_unauthorized(populated_network: Network, api_client
     assert r.status_code == 401
 
     # Assert relevant objects are not deleted
-    assert Network.objects.filter(name=populated_network.name).first() is not None
+    assert Network.objects.filter(name=populated_network.name).exists()
     assert workspace.get_arango_db().has_graph(populated_network.name)
 
 
@@ -136,7 +136,7 @@ def test_network_rest_delete_forbidden(
     assert r.status_code == 403
 
     # Assert relevant objects are not deleted
-    assert Network.objects.filter(name=network.name).first() is not None
+    assert Network.objects.filter(name=network.name).exists()
     assert workspace.get_arango_db().has_graph(network.name)
 
 

--- a/multinet/api/tests/test_placeholder.py
+++ b/multinet/api/tests/test_placeholder.py
@@ -1,3 +1,0 @@
-# Placeholder so pytest doesn't fail
-def test_placeholder():
-    pass

--- a/multinet/api/tests/test_table.py
+++ b/multinet/api/tests/test_table.py
@@ -1,0 +1,165 @@
+from faker import Faker
+import pytest
+from rest_framework.test import APIClient
+
+from multinet.api.models import Table, Workspace
+from multinet.api.tests.factories import TableFactory
+
+from .fuzzy import INTEGER_ID_RE, TIMESTAMP_RE, dict_to_fuzzy_arango_doc
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('edge', [True, False])
+def test_table_rest_create(
+    owned_workspace: Workspace, authenticated_api_client: APIClient, edge: bool
+):
+    table_name = Faker().pystr()
+    r = authenticated_api_client.post(
+        f'/api/workspaces/{owned_workspace.name}/tables/',
+        {'name': table_name, 'edge': edge},
+        format='json',
+    )
+    r_json = r.json()
+
+    assert r_json == {
+        'name': table_name,
+        'edge': edge,
+        'id': INTEGER_ID_RE,
+        'created': TIMESTAMP_RE,
+        'modified': TIMESTAMP_RE,
+        'workspace': {
+            'id': owned_workspace.pk,
+            'name': owned_workspace.name,
+            'created': TIMESTAMP_RE,
+            'modified': TIMESTAMP_RE,
+            'arango_db_name': owned_workspace.arango_db_name,
+        },
+    }
+
+    # Django will raise an exception if this fails, implicitly validating that the object exists
+    table: Table = Table.objects.get(name=table_name)
+
+    # Assert that object was created in arango
+    assert owned_workspace.get_arango_db().has_collection(table.name)
+
+
+@pytest.mark.django_db
+def test_table_rest_retrieve(owned_workspace: Workspace, authenticated_api_client: APIClient):
+    assert authenticated_api_client.get(f'/api/workspaces/{owned_workspace.name}/').data == {
+        'id': owned_workspace.pk,
+        'name': owned_workspace.name,
+        'created': TIMESTAMP_RE,
+        'modified': TIMESTAMP_RE,
+        'arango_db_name': owned_workspace.arango_db_name,
+    }
+
+
+@pytest.mark.django_db
+def test_table_rest_delete(
+    table_factory: TableFactory, owned_workspace: Workspace, authenticated_api_client: APIClient
+):
+    table: Table = table_factory(workspace=owned_workspace)
+
+    r = authenticated_api_client.delete(
+        f'/api/workspaces/{owned_workspace.name}/tables/{table.name}/'
+    )
+
+    assert r.status_code == 204
+
+    # Assert relevant objects are deleted
+    assert Table.objects.filter(name=owned_workspace.name).first() is None
+    assert not owned_workspace.get_arango_db().has_collection(table.name)
+
+
+@pytest.mark.django_db
+def test_table_rest_retrieve_rows(
+    table_factory: TableFactory, owned_workspace: Workspace, authenticated_api_client: APIClient
+):
+    table: Table = table_factory(workspace=owned_workspace)
+
+    table_rows = [{'foo': 'bar'}, {'foo2': 'bar2'}]
+    inserted_table_rows = list(map(dict_to_fuzzy_arango_doc, table_rows))
+
+    table.put_rows(table_rows)
+    r = authenticated_api_client.get(
+        f'/api/workspaces/{owned_workspace.name}/tables/{table.name}/rows/'
+    )
+
+    assert r.status_code == 200
+    assert r.json() == {
+        'count': 2,
+        'next': None,
+        'previous': None,
+        'results': inserted_table_rows,
+    }
+
+
+@pytest.mark.django_db
+def test_table_rest_upsert_rows(
+    table_factory: TableFactory, owned_workspace: Workspace, authenticated_api_client: APIClient
+):
+    table: Table = table_factory(workspace=owned_workspace)
+
+    # Test that rows are empty beforehand
+    r = authenticated_api_client.get(
+        f'/api/workspaces/{owned_workspace.name}/tables/{table.name}/rows/'
+    )
+
+    assert r.status_code == 200
+    assert r.json() == {
+        'count': 0,
+        'next': None,
+        'previous': None,
+        'results': [],
+    }
+
+    table_rows = [{'foo': 'bar'}, {'foo2': 'bar2'}]
+    inserted_table_rows = list(map(dict_to_fuzzy_arango_doc, table_rows))
+
+    # Test that rows are populated after
+    r = authenticated_api_client.put(
+        f'/api/workspaces/{owned_workspace.name}/tables/{table.name}/rows/',
+        table_rows,
+        format='json',
+    )
+
+    assert r.status_code == 200
+    assert r.json() == {
+        'inserted': inserted_table_rows,
+        'errors': [],
+    }
+
+
+@pytest.mark.django_db
+def test_table_rest_delete_rows(
+    table_factory: TableFactory, owned_workspace: Workspace, authenticated_api_client: APIClient
+):
+    table: Table = table_factory(workspace=owned_workspace)
+    table_rows = [{'foo': 'bar'}, {'foo2': 'bar2'}]
+
+    table.put_rows(table_rows)
+    inserted_table_rows = list(table.get_rows())
+
+    r = authenticated_api_client.delete(
+        f'/api/workspaces/{owned_workspace.name}/tables/{table.name}/rows/',
+        inserted_table_rows,
+        format='json',
+    )
+
+    assert r.status_code == 200
+    assert r.json() == {
+        'deleted': inserted_table_rows,
+        'errors': [],
+    }
+
+    r = authenticated_api_client.get(
+        f'/api/workspaces/{owned_workspace.name}/tables/{table.name}/rows/'
+    )
+
+    assert r.status_code == 200
+    assert r.json() == {
+        'count': 0,
+        'next': None,
+        'previous': None,
+        'results': [],
+    }

--- a/multinet/api/tests/test_table.py
+++ b/multinet/api/tests/test_table.py
@@ -5,7 +5,7 @@ from rest_framework.test import APIClient
 from multinet.api.models import Table, Workspace
 from multinet.api.tests.factories import TableFactory
 
-from .fuzzy import INTEGER_ID_RE, TIMESTAMP_RE, dict_to_fuzzy_arango_doc
+from .fuzzy import INTEGER_ID_RE, TIMESTAMP_RE, arango_doc_to_fuzzy_rev, dict_to_fuzzy_arango_doc
 from .utils import assert_limit_offset_results, generate_arango_documents
 
 
@@ -85,7 +85,7 @@ def test_table_rest_retrieve_rows(
 
 
 @pytest.mark.django_db
-def test_table_rest_upsert_rows(
+def test_table_rest_insert_rows(
     table_factory: TableFactory, owned_workspace: Workspace, authenticated_api_client: APIClient
 ):
     table: Table = table_factory(workspace=owned_workspace)
@@ -93,7 +93,7 @@ def test_table_rest_upsert_rows(
     table_rows = generate_arango_documents(5)
     inserted_table_rows = list(map(dict_to_fuzzy_arango_doc, table_rows))
 
-    # Test that rows are populated after
+    # Test insert response
     r = authenticated_api_client.put(
         f'/api/workspaces/{owned_workspace.name}/tables/{table.name}/rows/',
         table_rows,
@@ -105,6 +105,100 @@ def test_table_rest_upsert_rows(
         'inserted': inserted_table_rows,
         'errors': [],
     }
+
+    # Test that rows are populated after
+    r = authenticated_api_client.get(
+        f'/api/workspaces/{owned_workspace.name}/tables/{table.name}/rows/',
+    )
+
+    assert r.status_code == 200
+    assert r.json() == {
+        'count': len(table_rows),
+        'next': None,
+        'previous': None,
+        'results': inserted_table_rows,
+    }
+
+
+@pytest.mark.django_db
+def test_table_rest_update_rows(
+    populated_node_table: Table, owned_workspace: Workspace, authenticated_api_client: APIClient
+):
+
+    # Assert table contents beforehand
+    original_table_rows = list(populated_node_table.get_rows())
+    new_table_rows = [{**d, 'extra': 'field'} for d in original_table_rows]
+    inserted_new_table_rows = list(map(dict_to_fuzzy_arango_doc, new_table_rows))
+
+    # Assert row update succeeded
+    r = authenticated_api_client.put(
+        f'/api/workspaces/{owned_workspace.name}/tables/{populated_node_table.name}/rows/',
+        new_table_rows,
+        format='json',
+    )
+
+    assert r.status_code == 200
+    assert r.json() == {
+        'inserted': inserted_new_table_rows,
+        'errors': [],
+    }
+
+    # Assert only existing rows were updated, and no new ones were added
+    r = authenticated_api_client.get(
+        f'/api/workspaces/{owned_workspace.name}/tables/{populated_node_table.name}/rows/',
+    )
+
+    r_json = r.json()
+    assert r_json['count'] == len(original_table_rows)
+
+    for i, row in enumerate(r_json['results']):
+        assert row == inserted_new_table_rows[i]
+        assert row['_id'] == original_table_rows[i]['_id']
+
+
+@pytest.mark.django_db
+def test_table_rest_upsert_rows(
+    populated_node_table: Table, owned_workspace: Workspace, authenticated_api_client: APIClient
+):
+    # Create row lists
+    original_table_rows = list(populated_node_table.get_rows())
+    new_table_rows = generate_arango_documents(3)
+    partially_updated_table_rows = [{**d, 'extra': 'field'} for d in original_table_rows[:2]]
+    upsert_payload = [*partially_updated_table_rows, *new_table_rows]
+
+    # Create fuzzy row lists
+    fuzzy_new_table_rows = list(map(dict_to_fuzzy_arango_doc, new_table_rows))
+    fuzzy_partially_updated_table_rows = list(
+        map(arango_doc_to_fuzzy_rev, partially_updated_table_rows)
+    )
+    fuzzy_upsert_payload = [*fuzzy_partially_updated_table_rows, *fuzzy_new_table_rows]
+
+    # Test combined row insert/update
+    r = authenticated_api_client.put(
+        f'/api/workspaces/{owned_workspace.name}/tables/{populated_node_table.name}/rows/',
+        upsert_payload,
+        format='json',
+    )
+
+    assert r.status_code == 200
+    assert r.json() == {
+        'inserted': fuzzy_upsert_payload,
+        'errors': [],
+    }
+
+    # Test row population after
+    r = authenticated_api_client.get(
+        f'/api/workspaces/{owned_workspace.name}/tables/{populated_node_table.name}/rows/',
+    )
+
+    r_json = r.json()
+    assert r_json['count'] == len(original_table_rows) + len(new_table_rows)
+    for row in r_json['results']:
+        assert (
+            row in original_table_rows
+            or row in fuzzy_partially_updated_table_rows
+            or row in fuzzy_new_table_rows
+        )
 
 
 @pytest.mark.django_db

--- a/multinet/api/tests/test_table.py
+++ b/multinet/api/tests/test_table.py
@@ -90,7 +90,7 @@ def test_table_rest_delete(
     assert r.status_code == 204
 
     # Assert relevant objects are deleted
-    assert Table.objects.filter(name=owned_workspace.name).first() is None
+    assert not Table.objects.filter(name=owned_workspace.name).exists()
     assert not owned_workspace.get_arango_db().has_collection(table.name)
 
 
@@ -104,7 +104,7 @@ def test_table_rest_delete_unauthorized(
     assert r.status_code == 401
 
     # Assert relevant objects are not deleted
-    assert Table.objects.filter(name=table.name).first() is not None
+    assert Table.objects.filter(name=table.name).exists()
     assert owned_workspace.get_arango_db().has_collection(table.name)
 
 
@@ -122,7 +122,7 @@ def test_table_rest_delete_forbidden(
     assert r.status_code == 403
 
     # Assert relevant objects are not deleted
-    assert Table.objects.filter(name=table.name).first() is not None
+    assert Table.objects.filter(name=table.name).exists()
     assert workspace.get_arango_db().has_collection(table.name)
 
 

--- a/multinet/api/tests/test_workspace.py
+++ b/multinet/api/tests/test_workspace.py
@@ -1,11 +1,11 @@
-from django.contrib.auth.models import User
 from faker import Faker
-from guardian.shortcuts import assign_perm
 import pytest
 from rest_framework.test import APIClient
 
 from multinet.api.models import Workspace
 from multinet.api.utils.arango import arango_system_db
+
+from .fuzzy import TIMESTAMP_RE
 
 
 @pytest.mark.django_db
@@ -16,7 +16,7 @@ def test_workspace_arango_sync(workspace: Workspace):
 @pytest.mark.django_db
 def test_workspace_rest_create(authenticated_api_client: APIClient):
     fake = Faker()
-    workspace_name = fake.first_name()
+    workspace_name = fake.pystr()
 
     r = authenticated_api_client.post('/api/workspaces/', {'name': workspace_name}, format='json')
     r_json = r.json()
@@ -33,23 +33,18 @@ def test_workspace_rest_retrieve(workspace: Workspace, authenticated_api_client:
     assert authenticated_api_client.get(f'/api/workspaces/{workspace.name}/').data == {
         'id': workspace.pk,
         'name': workspace.name,
-        'created': workspace.created.isoformat().replace('+00:00', 'Z'),
-        'modified': workspace.modified.isoformat().replace('+00:00', 'Z'),
+        'created': TIMESTAMP_RE,
+        'modified': TIMESTAMP_RE,
         'arango_db_name': workspace.arango_db_name,
     }
 
 
 @pytest.mark.django_db
-def test_workspace_rest_delete(
-    user: User, workspace: Workspace, authenticated_api_client: APIClient
-):
-    # Ensure owner perms
-    assign_perm('owner', user, workspace)
-
-    r = authenticated_api_client.delete(f'/api/workspaces/{workspace.name}/')
+def test_workspace_rest_delete(owned_workspace: Workspace, authenticated_api_client: APIClient):
+    r = authenticated_api_client.delete(f'/api/workspaces/{owned_workspace.name}/')
 
     assert r.status_code == 204
 
     # Assert relevant objects are deleted
-    assert Workspace.objects.filter(name=workspace.name).first() is None
-    assert not arango_system_db().has_database(workspace.arango_db_name)
+    assert Workspace.objects.filter(name=owned_workspace.name).first() is None
+    assert not arango_system_db().has_database(owned_workspace.arango_db_name)

--- a/multinet/api/tests/test_workspace.py
+++ b/multinet/api/tests/test_workspace.py
@@ -1,0 +1,55 @@
+from django.contrib.auth.models import User
+from faker import Faker
+from guardian.shortcuts import assign_perm
+import pytest
+from rest_framework.test import APIClient
+
+from multinet.api.models import Workspace
+from multinet.api.utils.arango import arango_system_db
+
+
+@pytest.mark.django_db
+def test_workspace_arango_sync(workspace: Workspace):
+    assert arango_system_db().has_database(workspace.arango_db_name)
+
+
+@pytest.mark.django_db
+def test_workspace_rest_create(authenticated_api_client: APIClient):
+    fake = Faker()
+    workspace_name = fake.first_name()
+
+    r = authenticated_api_client.post('/api/workspaces/', {'name': workspace_name}, format='json')
+    r_json = r.json()
+
+    assert r_json['name'] == workspace_name
+    assert arango_system_db().has_database(r_json['arango_db_name'])
+
+    # Django will raise an exception if this fails
+    Workspace.objects.get(name=workspace_name)
+
+
+@pytest.mark.django_db
+def test_workspace_rest_retrieve(workspace: Workspace, authenticated_api_client: APIClient):
+    assert authenticated_api_client.get(f'/api/workspaces/{workspace.name}/').data == {
+        'id': workspace.pk,
+        'name': workspace.name,
+        'created': workspace.created.isoformat().replace('+00:00', 'Z'),
+        'modified': workspace.modified.isoformat().replace('+00:00', 'Z'),
+        'arango_db_name': workspace.arango_db_name,
+    }
+
+
+@pytest.mark.django_db
+def test_workspace_rest_delete(
+    user: User, workspace: Workspace, authenticated_api_client: APIClient
+):
+    # Ensure owner perms
+    assign_perm('owner', user, workspace)
+
+    r = authenticated_api_client.delete(f'/api/workspaces/{workspace.name}/')
+
+    assert r.status_code == 204
+
+    # Assert relevant objects are deleted
+    assert Workspace.objects.filter(name=workspace.name).first() is None
+    assert not arango_system_db().has_database(workspace.arango_db_name)

--- a/multinet/api/tests/test_workspace.py
+++ b/multinet/api/tests/test_workspace.py
@@ -68,7 +68,7 @@ def test_workspace_rest_delete(owned_workspace: Workspace, authenticated_api_cli
     assert r.status_code == 204
 
     # Assert relevant objects are deleted
-    assert Workspace.objects.filter(name=owned_workspace.name).first() is None
+    assert not Workspace.objects.filter(name=owned_workspace.name).exists()
     assert not arango_system_db().has_database(owned_workspace.arango_db_name)
 
 
@@ -79,7 +79,7 @@ def test_workspace_rest_delete_unauthorized(owned_workspace: Workspace, api_clie
     assert r.status_code == 401
 
     # Assert relevant objects are not deleted
-    assert Workspace.objects.filter(name=owned_workspace.name).first() is not None
+    assert Workspace.objects.filter(name=owned_workspace.name).exists()
     assert arango_system_db().has_database(owned_workspace.arango_db_name)
 
 
@@ -94,5 +94,5 @@ def test_workspace_rest_delete_forbidden(
     assert r.status_code == 403
 
     # Assert relevant objects are not deleted
-    assert Workspace.objects.filter(name=workspace.name).first() is not None
+    assert Workspace.objects.filter(name=workspace.name).exists()
     assert arango_system_db().has_database(workspace.arango_db_name)

--- a/multinet/api/tests/utils.py
+++ b/multinet/api/tests/utils.py
@@ -1,0 +1,28 @@
+from typing import Dict, List
+
+from rest_framework.test import APIClient
+
+
+def generate_arango_documents(n: int, num_fields: int = 3) -> List[Dict]:
+    """Generate n number of test documents, each containing num_fields fields."""
+    return [{f'foo{i}_{ii}': f'bar{i}_{ii}' for ii in range(num_fields)} for i in range(n)]
+
+
+def assert_limit_offset_results(client: APIClient, url: str, _list: List):
+    """
+    Assert that a limit/offset endpoint performs correct pagination.
+
+    This is done by making the desired request with all of the relevant limit/offset permutations.
+    """
+    l_range = range(len(_list))
+    for limit in l_range:
+        for offset in l_range:
+            r = client.get(
+                url,
+                {'limit': limit, 'offset': offset},
+            )
+
+            r_json = r.json()
+            assert r.status_code == 200
+            assert r_json['count'] == limit or len(_list)
+            assert r_json['results'] == _list[offset : (limit + offset if limit else None)]

--- a/multinet/api/utils/arango.py
+++ b/multinet/api/utils/arango.py
@@ -4,6 +4,7 @@ from functools import lru_cache
 from typing import Dict, List, Optional
 
 from arango import ArangoClient
+from arango.cursor import Cursor
 from arango.database import StandardDatabase
 from django.conf import settings
 
@@ -73,3 +74,11 @@ class ArangoQuery:
 
         new_query_str = f'FOR doc IN ({self.query_str}) LIMIT {offset}, {limit} RETURN doc'
         return ArangoQuery(self.db, query_str=new_query_str, bind_vars=self.bind_vars)
+
+    def execute(self, **kwargs) -> Cursor:
+        """
+        Execute an AQL query with the instantiated query_str and bind_vars.
+
+        Accepts the same keyword arguments as `arango.database.StandardDatabase.aql.execute`.
+        """
+        return self.db.aql.execute(query=self.query_str, bind_vars=self.bind_vars, **kwargs)

--- a/multinet/api/views/common.py
+++ b/multinet/api/views/common.py
@@ -55,9 +55,7 @@ class ArangoPagination(LimitOffsetPagination):
         self._set_pre_query_params(request)
 
         paginated_query = query.paginate(self.limit, self.offset)
-        cur: Cursor = query.db.aql.execute(
-            query=paginated_query.query_str, bind_vars=paginated_query.bind_vars, full_count=True
-        )
+        cur: Cursor = paginated_query.execute(full_count=True)
 
         self.count = cur.statistics()['fullCount']
         self._set_post_query_params()

--- a/multinet/api/views/network.py
+++ b/multinet/api/views/network.py
@@ -151,12 +151,8 @@ class NetworkViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelVie
             return response
 
         network: Network = get_object_or_404(Network, name=name)
-
-        response = get_40x_or_None(request, ['owner'], network, return_403=True)
-        if response:
-            return response
-
         network.delete()
+
         return Response(None, status=status.HTTP_204_NO_CONTENT)
 
     @swagger_auto_schema(
@@ -165,6 +161,8 @@ class NetworkViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelVie
     )
     @action(detail=True, url_path='nodes')
     def nodes(self, request, parent_lookup_workspace__name: str, name: str):
+        # Doesn't use the Network.nodes method, in order to do proper pagination.
+
         workspace: Workspace = get_object_or_404(Workspace, name=parent_lookup_workspace__name)
         network: Network = get_object_or_404(Network, workspace=workspace, name=name)
 
@@ -180,6 +178,8 @@ class NetworkViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelVie
     )
     @action(detail=True, url_path='edges')
     def edges(self, request, parent_lookup_workspace__name: str, name: str):
+        # Doesn't use the Network.edges method, in order to do proper pagination.
+
         workspace: Workspace = get_object_or_404(Workspace, name=parent_lookup_workspace__name)
         network: Network = get_object_or_404(Network, workspace=workspace, name=name)
 

--- a/multinet/api/views/table.py
+++ b/multinet/api/views/table.py
@@ -87,12 +87,8 @@ class TableViewSet(ReadOnlyModelViewSet):
             return response
 
         table: Table = get_object_or_404(Table, name=name)
-
-        response = get_40x_or_None(request, ['owner'], table, return_403=True)
-        if response:
-            return response
-
         table.delete()
+
         return Response(None, status=status.HTTP_204_NO_CONTENT)
 
     @swagger_auto_schema(

--- a/multinet/api/views/table.py
+++ b/multinet/api/views/table.py
@@ -9,6 +9,7 @@ from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.response import Response
 from rest_framework.viewsets import ReadOnlyModelViewSet
+from rest_framework_extensions.mixins import NestedViewSetMixin
 
 from multinet.api.models import Table, Workspace
 from multinet.api.utils.arango import ArangoQuery
@@ -37,7 +38,7 @@ class RowDeleteResponseSerializer(serializers.Serializer):
     errors = serializers.ListField(child=serializers.JSONField())
 
 
-class TableViewSet(ReadOnlyModelViewSet):
+class TableViewSet(NestedViewSetMixin, ReadOnlyModelViewSet):
     queryset = Table.objects.all().select_related('workspace')
     lookup_field = 'name'
 


### PR DESCRIPTION
Fixes #16.

This PR adds some initial tests and testing infrastructure, as well as fixes several bugs that were discovered in the process.

For Workspaces, Tables, and Networks, the following common endpoints are tested:
* Listing
* Retrieval
* Creation
* Deletion (+ unauthorized and forbidden deletes)

For just Tables and workspaces, the extra endpoints related to data retrieval are tested. These are:

* Table
	* Row retrieval
	* Row insertion
	* Row update
	* Row upsert
	* Row deletion
* Network
	* Node retrieval
	* Edge retrieval

The following additions were made to the core application code:
* Add `nodes` and `edges` methods to the `Network` model. This is to allow access of these independent of the rest endpoints. Notably, the rest endpoints do **not** actually use these methods, as they need to perform pagination in a separate way.
* An `execute` method was added to the `ArangoQuery` class, making them easier to execute.

The following bugs were fixed in the core application code:
* Fixed unconditional `403 Forbidden` response in Table delete endpoint
* Fixed unconditional `403 Forbidden` response in Network delete endpoint
* Fixed bug in TableViewSet, where the parent workspace lookup wasn't used