### PR TITLE
Improve Swagger Page

### DIFF
--- a/multinet/api/utils/swagger.py
+++ b/multinet/api/utils/swagger.py
@@ -1,0 +1,12 @@
+from drf_yasg.inspectors import SwaggerAutoSchema
+
+VIEWSET_TAGS_FIELD = 'swagger_tags'
+
+
+class ImprovedAutoSchema(SwaggerAutoSchema):
+    def get_tags(self, operation_keys=None):
+        tags = self.overrides.get('tags') or getattr(self.view, VIEWSET_TAGS_FIELD, [])
+        if not tags and operation_keys:
+            tags = [operation_keys[0]]
+
+        return tags

--- a/multinet/api/views/network.py
+++ b/multinet/api/views/network.py
@@ -88,6 +88,9 @@ class NetworkViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelVie
 
     pagination_class = MultinetPagination
 
+    # Categorize entire ViewSet
+    swagger_tags = ['networks']
+
     @swagger_auto_schema(
         request_body=NetworkCreateSerializer(),
         responses={200: NetworkReturnSerializer()},

--- a/multinet/api/views/table.py
+++ b/multinet/api/views/table.py
@@ -50,6 +50,9 @@ class TableViewSet(NestedViewSetMixin, ReadOnlyModelViewSet):
 
     pagination_class = MultinetPagination
 
+    # Categorize entire ViewSet
+    swagger_tags = ['tables']
+
     @swagger_auto_schema(
         request_body=TableCreateSerializer(),
         responses={200: TableReturnSerializer()},

--- a/multinet/api/views/workspace.py
+++ b/multinet/api/views/workspace.py
@@ -26,6 +26,9 @@ class WorkspaceViewSet(ReadOnlyModelViewSet):
 
     pagination_class = PageNumberPagination
 
+    # Categorize entire ViewSet
+    swagger_tags = ['workspaces']
+
     @swagger_auto_schema(
         request_body=WorkspaceCreateSerializer(),
         responses={200: WorkspaceSerializer()},

--- a/multinet/settings.py
+++ b/multinet/settings.py
@@ -35,6 +35,9 @@ class MultinetMixin(ConfigMixin):
 
     MULTINET_ARANGO_URL = values.Value(environ_required=True)
     MULTINET_ARANGO_PASSWORD = values.Value(environ_required=True)
+    SWAGGER_SETTINGS = {
+        'DEFAULT_AUTO_SCHEMA_CLASS': 'multinet.api.utils.swagger.ImprovedAutoSchema'
+    }
 
 
 class DevelopmentConfiguration(MultinetMixin, DevelopmentBaseConfiguration):

--- a/multinet/urls.py
+++ b/multinet/urls.py
@@ -31,7 +31,7 @@ workspaces_routes.register(
 
 # OpenAPI generation
 schema_view = get_schema_view(
-    openapi.Info(title='multinet', default_version='v1', description=''),
+    openapi.Info(title='multinet', default_version='v1'),
     public=True,
     permission_classes=(permissions.AllowAny,),
 )
@@ -40,7 +40,7 @@ urlpatterns = [
     path('accounts/', include('allauth.urls')),
     path('oauth/', include('oauth2_provider.urls', namespace='oauth2_provider')),
     path('admin/', admin.site.urls),
-    path('api/s3-upload/', include('s3_file_field.urls')),
+    path('api/upload/', include('s3_file_field.urls')),
     path('api/', include(router.urls)),
     path('api/users/me', users_me_view),
     path('api/users/search', users_search_view),


### PR DESCRIPTION
This does two things:

* Organizes the endpoints by operation (workspaces, tables, networks)
* Renames `s3-upload` to `upload`