### PR TITLE
Update row retrieval, insertion and deletion

### DIFF
--- a/multinet/api/models/table.py
+++ b/multinet/api/models/table.py
@@ -10,12 +10,8 @@ from django.db import models
 from django.db.models.signals import post_delete, pre_save
 from django.dispatch.dispatcher import receiver
 from django_extensions.db.models import TimeStampedModel
-from more_itertools import chunked
 
 from .workspace import Workspace
-
-# The max number of documents that should be sent in bulk requests
-DOCUMENT_CHUNK_SIZE = 5000
 
 
 @dataclass
@@ -62,36 +58,24 @@ class Table(TimeStampedModel):
 
     def put_rows(self, rows: List[Dict]) -> RowInsertionResponse:
         """Insert/update rows in the underlying arangodb collection."""
-        errors = []
-
-        # Limit the amount of rows inserted per request, to prevent timeouts
-        for chunk in chunked(rows, DOCUMENT_CHUNK_SIZE):
-            res = self.get_arango_collection().insert_many(chunk, overwrite=True)
-            errors.extend(
-                (
-                    RowModifyError(index=i, message=doc.error_message)
-                    for i, doc in enumerate(res)
-                    if isinstance(doc, DocumentInsertError)
-                )
-            )
+        res = self.get_arango_collection().insert_many(rows, overwrite=True)
+        errors = [
+            RowModifyError(index=i, message=doc.error_message)
+            for i, doc in enumerate(res)
+            if isinstance(doc, DocumentInsertError)
+        ]
 
         inserted = len(rows) - len(errors)
         return RowInsertionResponse(inserted=inserted, errors=errors)
 
     def delete_rows(self, rows: List[Dict]) -> RowDeletionResponse:
         """Delete rows in the underlying arangodb collection."""
-        errors = []
-
-        # Limit the amount of rows deleted per request, to prevent timeouts
-        for chunk in chunked(rows, DOCUMENT_CHUNK_SIZE):
-            res = self.get_arango_collection().delete_many(chunk)
-            errors.extend(
-                (
-                    RowModifyError(index=i, message=doc.error_message)
-                    for i, doc in enumerate(res)
-                    if isinstance(doc, DocumentDeleteError)
-                )
-            )
+        res = self.get_arango_collection().delete_many(rows)
+        errors = [
+            RowModifyError(index=i, message=doc.error_message)
+            for i, doc in enumerate(res)
+            if isinstance(doc, DocumentDeleteError)
+        ]
 
         deleted = len(rows) - len(errors)
         return RowDeletionResponse(deleted=deleted, errors=errors)

--- a/multinet/api/tests/test_table.py
+++ b/multinet/api/tests/test_table.py
@@ -143,14 +143,14 @@ def test_table_rest_retrieve_rows(
 def test_table_rest_retrieve_rows_filter_invalid(
     populated_node_table: Table, owned_workspace: Workspace, authenticated_api_client: APIClient
 ):
-    """Test that the use of an invalid filter param doesn't cause an error."""
-    table_rows = list(populated_node_table.get_rows())
-    assert_limit_offset_results(
-        authenticated_api_client,
+    """Test that the use of an invalid filter param returns the expected error."""
+    r = authenticated_api_client.get(
         f'/api/workspaces/{owned_workspace.name}/tables/{populated_node_table.name}/rows/',
-        table_rows,
-        params={'filter': 'foobar'},  # Should be a JSON string, not 'foobar'
+        {'filter': 'foobar'},  # Should be a JSON string, not 'foobar'
     )
+
+    assert r.status_code == 400
+    assert 'filter' in r.json()
 
 
 @pytest.mark.django_db

--- a/multinet/api/tests/test_table.py
+++ b/multinet/api/tests/test_table.py
@@ -266,7 +266,7 @@ def test_table_rest_delete_rows(
 
     assert r.status_code == 200
     assert r.json() == {
-        'deleted': table_rows,
+        'deleted': len(table_rows),
         'errors': [],
     }
 

--- a/multinet/api/tests/utils.py
+++ b/multinet/api/tests/utils.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from rest_framework.test import APIClient
 
@@ -8,21 +8,24 @@ def generate_arango_documents(n: int, num_fields: int = 3) -> List[Dict]:
     return [{f'foo{i}_{ii}': f'bar{i}_{ii}' for ii in range(num_fields)} for i in range(n)]
 
 
-def assert_limit_offset_results(client: APIClient, url: str, _list: List):
+def assert_limit_offset_results(
+    client: APIClient, url: str, result: List, params: Optional[Dict] = None
+):
     """
     Assert that a limit/offset endpoint performs correct pagination.
 
     This is done by making the desired request with all of the relevant limit/offset permutations.
     """
-    l_range = range(len(_list))
+    query_params = params or {}
+    l_range = range(len(result))
     for limit in l_range:
         for offset in l_range:
             r = client.get(
                 url,
-                {'limit': limit, 'offset': offset},
+                {**query_params, 'limit': limit, 'offset': offset},
             )
 
             r_json = r.json()
             assert r.status_code == 200
-            assert r_json['count'] == limit or len(_list)
-            assert r_json['results'] == _list[offset : (limit + offset if limit else None)]
+            assert r_json['count'] == limit or len(result)
+            assert r_json['results'] == result[offset : (limit + offset if limit else None)]

--- a/multinet/api/utils/arango.py
+++ b/multinet/api/utils/arango.py
@@ -78,7 +78,22 @@ class ArangoQuery:
         return ArangoQuery(db, query_str=query_str, bind_vars=bind_vars)
 
     def filter(self, doc: Dict) -> ArangoQuery:
-        """Filter an AQL query to match the provided document."""
+        """
+        Filter an AQL query to match the provided document.
+
+        This function transforms a dict into the syntax required for filtering an AQL query.
+        For example, the dict `{"foo": "bar"}` would become `FILTER doc['foo'] == 'bar'`.
+        This is done by creating bind variables for each key and value used, and then injecting
+        those variables into the query (to prevent any unwanted behavior from injected variables).
+        So instead of directly using the variables as shown in the above example query, the
+        following would be done::
+
+            bind_vars = {"f2e59b48": "foo", "a7f3755d": "bar"}
+            query_str = "FILTER doc[@f2e59b48] == @a7f3755d"
+
+        Since a dict almost always has multiple key/value pairs, this is done for every pair and
+        joined together into the final query.
+        """
         # If empty filter, do nothing
         if not doc:
             return self

--- a/multinet/api/utils/arango.py
+++ b/multinet/api/utils/arango.py
@@ -14,7 +14,8 @@ from django.conf import settings
 class NoTimeoutHttpClient(DefaultHTTPClient):
     """Extend the default arango http client, to remove timeouts for bulk data."""
 
-    REQUEST_TIMEOUT = None
+    # Set the request timeout to 1 hour (in seconds)
+    REQUEST_TIMEOUT = 60 * 60
 
 
 @lru_cache()

--- a/multinet/api/utils/arango.py
+++ b/multinet/api/utils/arango.py
@@ -83,18 +83,23 @@ class ArangoQuery:
         if not doc:
             return self
 
+        # Iterate through the dict, storing each key/value pair as bind vars,
+        # and creating a query filter using them
         new_bind_vars = dict(self.bind_vars)
         filter_query_lines = []
         for k, v in doc.items():
-            # Create unique bind var keys, so they don't
-            # conflict with any previous or future keys
+            # Create unique bind var keys for dict key and value
             key_key = str(uuid.uuid4())[:8]
             val_key = str(uuid.uuid4())[:8]
 
+            # Store the dict key and value using the generated keys
             new_bind_vars[key_key] = k
             new_bind_vars[val_key] = v
+
+            # Reference the variable keys in the query
             filter_query_lines.append(f'doc[@{key_key}] == @{val_key}')
 
+        # Join the filters and wrap query
         filter_query_str = ' and '.join(filter_query_lines)
         new_query_str = f'FOR doc IN ({self.query_str}) FILTER ({filter_query_str}) RETURN doc'
         return ArangoQuery(self.db, query_str=new_query_str, bind_vars=new_bind_vars)

--- a/multinet/api/utils/arango.py
+++ b/multinet/api/utils/arango.py
@@ -7,12 +7,19 @@ import uuid
 from arango import ArangoClient
 from arango.cursor import Cursor
 from arango.database import StandardDatabase
+from arango.http import DefaultHTTPClient
 from django.conf import settings
+
+
+class NoTimeoutHttpClient(DefaultHTTPClient):
+    """Extend the default arango http client, to remove timeouts for bulk data."""
+
+    REQUEST_TIMEOUT = None
 
 
 @lru_cache()
 def arango_client():
-    return ArangoClient(hosts=settings.MULTINET_ARANGO_URL)
+    return ArangoClient(hosts=settings.MULTINET_ARANGO_URL, http_client=NoTimeoutHttpClient())
 
 
 def db(name: str):

--- a/multinet/api/views/table.py
+++ b/multinet/api/views/table.py
@@ -1,8 +1,10 @@
 from dataclasses import asdict
+import json
 
 from django.shortcuts import get_object_or_404
 from django.utils.decorators import method_decorator
 from django_filters import rest_framework as filters
+from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 from guardian.decorators import permission_required_or_403
 from rest_framework import serializers, status
@@ -93,7 +95,10 @@ class TableViewSet(NestedViewSetMixin, ReadOnlyModelViewSet):
         return Response(None, status=status.HTTP_204_NO_CONTENT)
 
     @swagger_auto_schema(
-        manual_parameters=LIMIT_OFFSET_QUERY_PARAMS,
+        manual_parameters=[
+            openapi.Parameter('filter', 'query', type='object'),
+            *LIMIT_OFFSET_QUERY_PARAMS,
+        ],
         responses={200: PAGINATED_RESULTS_SCHEMA},
     )
     @action(detail=True, url_path='rows')
@@ -103,8 +108,14 @@ class TableViewSet(NestedViewSetMixin, ReadOnlyModelViewSet):
 
         pagination = ArangoPagination()
         query = ArangoQuery.from_collections(workspace.get_arango_db(), [table.name])
-        paginated_query = pagination.paginate_queryset(query, request)
 
+        # Attempt filtering
+        try:
+            query = query.filter(json.loads(request.query_params.get('filter', '{}')))
+        except json.JSONDecodeError:
+            pass
+
+        paginated_query = pagination.paginate_queryset(query, request)
         return pagination.get_paginated_response(paginated_query)
 
     @swagger_auto_schema(

--- a/multinet/api/views/table.py
+++ b/multinet/api/views/table.py
@@ -35,7 +35,7 @@ class RowInsertResponseSerializer(serializers.Serializer):
 
 
 class RowDeleteResponseSerializer(serializers.Serializer):
-    deleted = serializers.ListField(child=serializers.JSONField())
+    deleted = serializers.IntegerField()
     errors = serializers.ListField(child=serializers.JSONField())
 
 

--- a/multinet/api/views/table.py
+++ b/multinet/api/views/table.py
@@ -30,7 +30,7 @@ from .common import (
 
 
 class RowInsertResponseSerializer(serializers.Serializer):
-    inserted = serializers.ListField(child=serializers.JSONField())
+    inserted = serializers.IntegerField()
     errors = serializers.ListField(child=serializers.JSONField())
 
 

--- a/multinet/api/views/table.py
+++ b/multinet/api/views/table.py
@@ -112,8 +112,11 @@ class TableViewSet(NestedViewSetMixin, ReadOnlyModelViewSet):
         # Attempt filtering
         try:
             query = query.filter(json.loads(request.query_params.get('filter', '{}')))
-        except json.JSONDecodeError:
-            pass
+        except json.JSONDecodeError as e:
+            return Response(
+                {'filter': [str(e)]},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
         paginated_query = pagination.paginate_queryset(query, request)
         return pagination.get_paginated_response(paginated_query)

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         'djangorestframework',
         'drf-extensions',
         'drf-yasg',
+        'more-itertools',
         'python-arango',
         # Production-only
         'gunicorn',

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,6 @@ setup(
         'djangorestframework',
         'drf-extensions',
         'drf-yasg',
-        'more-itertools',
         'python-arango',
         # Production-only
         'gunicorn',


### PR DESCRIPTION
Closes #37 

This PR contains the following changes:

* Removes the returning of new/old documents when calling the row insert/delete endpoints, simply returning the number of documents inserted/deleted instead.
* Update the arango client to not timeout after 60 seconds, to allow for bulk document uploads.
* Add a `filter` parameter to the row retrieval endpoint, to allow passing in an arango document/sub-document to filter the returned documents. This is to fill a gap left by removing the returning of new documents.


Originally #37 proposed chunking the calls to `insert_many` in order to mitigate the chance of timeout. However, there are still many circumstances where that solution falls short. The solution put forth in this PR (removing timeouts in our arango client) allows for bulk uploads to succeed, while also allowing for chunking from the API surface if need be.