### PR TITLE
Add automatic task state handling

### DIFF
--- a/multinet/api/tasks/process/csv.py
+++ b/multinet/api/tasks/process/csv.py
@@ -7,11 +7,7 @@ from celery.utils.log import get_task_logger
 
 from multinet.api.models import Table, Upload
 
-from .utils import (
-    ColumnTypeEnum,
-    ProcessUploadTask,
-    processor_dict,
-)
+from .utils import ColumnTypeEnum, ProcessUploadTask, processor_dict
 
 logger = get_task_logger(__name__)
 

--- a/multinet/api/tasks/process/csv.py
+++ b/multinet/api/tasks/process/csv.py
@@ -42,12 +42,7 @@ def process_row(row: Dict[str, Any], cols: Dict[str, ColumnTypeEnum]) -> Dict:
 def process_csv(
     upload_id: int, table_name: str, edge: bool, columns: Dict[str, ColumnTypeEnum]
 ) -> None:
-    logger.info(f'Begin processing of upload {upload_id}')
     upload: Upload = Upload.objects.get(id=upload_id)
-
-    # Update status
-    upload.status = Upload.UploadStatus.STARTED
-    upload.save()
 
     # Download data from S3/MinIO
     with upload.blob as blob_file:

--- a/multinet/api/tasks/process/csv.py
+++ b/multinet/api/tasks/process/csv.py
@@ -47,10 +47,7 @@ def process_csv(
     # Download data from S3/MinIO
     with upload.blob as blob_file:
         blob_file: BinaryIO = blob_file
-        try:
-            csv_rows = list(csv.DictReader(StringIO(blob_file.read().decode('utf-8'))))
-        except csv.Error:
-            return ProcessUploadTask.fail_upload_with_message(upload, 'Failed to parse CSV.')
+        csv_rows = list(csv.DictReader(StringIO(blob_file.read().decode('utf-8'))))
 
     # Cast entries in each row to appropriate type, if necessary
     for i, row in enumerate(csv_rows):

--- a/multinet/api/tasks/process/d3_json.py
+++ b/multinet/api/tasks/process/d3_json.py
@@ -38,10 +38,7 @@ def process_d3_json(
     # Download data from S3/MinIO
     with upload.blob as blob_file:
         blob_file: BinaryIO
-        try:
-            d3_dict = json.loads(blob_file.read().decode('utf-8'))
-        except json.JSONDecodeError:
-            return ProcessUploadTask.fail_upload_with_message(upload, 'Failed to parse JSON.')
+        d3_dict = json.loads(blob_file.read().decode('utf-8'))
 
     # Change column names from the d3 format to the arango format
     d3_dict['nodes'] = [d3_node_to_arango_doc(node) for node in d3_dict['nodes']]

--- a/multinet/api/tasks/process/d3_json.py
+++ b/multinet/api/tasks/process/d3_json.py
@@ -33,12 +33,7 @@ def process_d3_json(
     node_table_name: str,
     edge_table_name: str,
 ) -> None:
-    logger.info(f'Begin processing of upload {upload_id}')
     upload: Upload = Upload.objects.get(id=upload_id)
-
-    # Update status
-    upload.status = Upload.UploadStatus.STARTED
-    upload.save()
 
     # Download data from S3/MinIO
     with upload.blob as blob_file:

--- a/multinet/api/tasks/process/utils.py
+++ b/multinet/api/tasks/process/utils.py
@@ -9,7 +9,6 @@ from dateutil import parser as dateutilparser
 
 from multinet.api.models import Upload
 
-
 logger = get_task_logger(__name__)
 
 

--- a/multinet/api/views/upload.py
+++ b/multinet/api/views/upload.py
@@ -90,7 +90,7 @@ class UploadViewSet(NestedViewSetMixin, ReadOnlyModelViewSet):
 
         # Dispatch task
         process_csv.delay(
-            upload.pk,
+            upload_id=upload.pk,
             table_name=table_name,
             edge=serializer.validated_data['edge'],
             columns=serializer.validated_data['columns'],
@@ -148,7 +148,7 @@ class UploadViewSet(NestedViewSetMixin, ReadOnlyModelViewSet):
 
         # Dispatch task
         process_d3_json.delay(
-            upload.pk,
+            upload_id=upload.pk,
             network_name=network_name,
             node_table_name=node_table_name,
             edge_table_name=edge_table_name,


### PR DESCRIPTION
Closes #44

This PR adds a `ProcessUploadTask` class, which extends Celery's default `Task` class, to allow for automatic updating of upload statuses. Now when dispatching a task, the following occurs automatically:

1. The logger prints that the upload is being processed
2. The upload status is changed to `STARTED`
3. The task is run
4. If any exception occurs during the task execution, the upload status is changed to `FAILED`, and the error message associated is included in the `error_messages` field
5. If the task completes successfully, the upload status is changed to `FINISHED`.
