### PR TITLE
Parametrize API endpoint tests

### DIFF
--- a/multinet/api/tests/factories.py
+++ b/multinet/api/tests/factories.py
@@ -38,7 +38,7 @@ class NetworkFactory(factory.django.DjangoModelFactory):
         model = Network
 
     name = factory.fuzzy.FuzzyText()
-    workspace = factory.SubFactory(PrivateWorkspaceFactory)
+    workspace = factory.LazyAttribute(lambda _: PrivateWorkspaceFactory())
 
 
 class EdgeTableFactory(factory.django.DjangoModelFactory):
@@ -46,7 +46,7 @@ class EdgeTableFactory(factory.django.DjangoModelFactory):
         model = Table
 
     name = factory.fuzzy.FuzzyText()
-    workspace = factory.SubFactory(PrivateWorkspaceFactory)
+    workspace = factory.LazyAttribute(lambda _: PrivateWorkspaceFactory())
     edge = True
 
 
@@ -55,7 +55,7 @@ class NodeTableFactory(factory.django.DjangoModelFactory):
         model = Table
 
     name = factory.fuzzy.FuzzyText()
-    workspace = factory.SubFactory(PrivateWorkspaceFactory)
+    workspace = factory.LazyAttribute(lambda _: PrivateWorkspaceFactory())
 
 
 # Default table to node table
@@ -67,5 +67,5 @@ class UploadFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Upload
 
-    workspace = factory.SubFactory(PrivateWorkspaceFactory)
-    user = factory.SubFactory(UserFactory)
+    workspace = factory.LazyAttribute(lambda _: PrivateWorkspaceFactory())
+    user = factory.LazyAttribute(lambda _: UserFactory())

--- a/multinet/api/tests/test_network.py
+++ b/multinet/api/tests/test_network.py
@@ -6,10 +6,7 @@ import pytest
 from rest_framework.test import APIClient
 
 from multinet.api.models import Network, Table, Workspace, WorkspaceRoleChoice
-from multinet.api.tests.factories import (
-    NetworkFactory,
-    PublicWorkspaceFactory,
-)
+from multinet.api.tests.factories import NetworkFactory, PublicWorkspaceFactory
 from multinet.api.tests.utils import assert_limit_offset_results
 
 from .conftest import populated_network, populated_table

--- a/multinet/api/tests/test_network.py
+++ b/multinet/api/tests/test_network.py
@@ -8,40 +8,56 @@ from rest_framework.test import APIClient
 from multinet.api.models import Network, Table, Workspace, WorkspaceRoleChoice
 from multinet.api.tests.factories import (
     NetworkFactory,
-    PrivateWorkspaceFactory,
     PublicWorkspaceFactory,
 )
 from multinet.api.tests.utils import assert_limit_offset_results
 
 from .conftest import populated_network, populated_table
 from .fuzzy import INTEGER_ID_RE, TIMESTAMP_RE
-from .utils import workspace_role_range
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('permission', workspace_role_range())
+@pytest.mark.parametrize(
+    'permission,is_owner,status_code,success',
+    [
+        (None, False, 404, False),
+        (WorkspaceRoleChoice.READER, False, 200, True),
+        (WorkspaceRoleChoice.WRITER, False, 200, True),
+        (WorkspaceRoleChoice.MAINTAINER, False, 200, True),
+        (None, True, 200, True),
+    ],
+)
 def test_network_rest_list(
     network_factory: NetworkFactory,
     workspace: Workspace,
     user: User,
     authenticated_api_client: APIClient,
     permission: WorkspaceRoleChoice,
+    is_owner: bool,
+    status_code: int,
+    success: bool,
 ):
-    workspace.set_user_permission(user, permission)
+    if permission is not None:
+        workspace.set_user_permission(user, permission)
+    elif is_owner:
+        workspace.set_owner(user)
     fake = Faker()
     network_names: List[str] = [
         network_factory(name=fake.pystr(), workspace=workspace).name for _ in range(3)
     ]
 
     r = authenticated_api_client.get(f'/api/workspaces/{workspace.name}/networks/')
-    r_json = r.json()
+    assert r.status_code == status_code
 
-    # Test that we get the expected results from both django and arango
-    arango_db = workspace.get_arango_db()
-    assert r_json['count'] == len(network_names)
-    for network in r_json['results']:
-        assert network['name'] in network_names
-        assert arango_db.has_graph(network['name'])
+    if success:
+        r_json = r.json()
+
+        # Test that we get the expected results from both django and arango
+        arango_db = workspace.get_arango_db()
+        assert r_json['count'] == len(network_names)
+        for network in r_json['results']:
+            assert network['name'] in network_names
+            assert arango_db.has_graph(network['name'])
 
 
 @pytest.mark.django_db
@@ -50,7 +66,7 @@ def test_network_rest_list_public(
     public_workspace_factory: PublicWorkspaceFactory,
     api_client: APIClient,
 ):
-    """Test that an authenticated user can see networks on a public workspace."""
+    """Test that an unauthenticated user can see networks on a public workspace."""
     fake = Faker()
     public_workspace: Workspace = public_workspace_factory()
     network_names: List[str] = [
@@ -67,33 +83,29 @@ def test_network_rest_list_public(
 
 
 @pytest.mark.django_db
-def test_network_rest_list_private(
-    network_factory: NetworkFactory,
-    private_workspace_factory: PrivateWorkspaceFactory,
-    authenticated_api_client: APIClient,
-):
-    """Test that an authenticated user can not see networks on a private workspace."""
-    fake = Faker()
-    private_workspace: Workspace = private_workspace_factory()
-    for _ in range(3):
-        network_factory(name=fake.pystr(), workspace=private_workspace)
-
-    r = authenticated_api_client.get(f'/api/workspaces/{private_workspace.name}/networks/')
-    assert r.status_code == 404
-
-
-@pytest.mark.django_db
 @pytest.mark.parametrize(
-    'permission',
-    workspace_role_range(min_role=WorkspaceRoleChoice.WRITER),
+    'permission,is_owner,status_code,success',
+    [
+        (None, False, 404, False),
+        (WorkspaceRoleChoice.READER, False, 403, False),
+        (WorkspaceRoleChoice.WRITER, False, 200, True),
+        (WorkspaceRoleChoice.MAINTAINER, False, 200, True),
+        (None, True, 200, True),
+    ],
 )
 def test_network_rest_create(
     workspace: Workspace,
     user: User,
     authenticated_api_client: APIClient,
     permission: WorkspaceRoleChoice,
+    is_owner: bool,
+    status_code: int,
+    success: bool,
 ):
-    workspace.set_user_permission(user, permission)
+    if permission is not None:
+        workspace.set_user_permission(user, permission)
+    elif is_owner:
+        workspace.set_owner(user)
 
     edge_table = populated_table(workspace, True)
     node_table_name = list(edge_table.find_referenced_node_tables().keys())[0]
@@ -105,92 +117,79 @@ def test_network_rest_create(
         {'name': network_name, 'edge_table': edge_table.name},
         format='json',
     )
+    assert r.status_code == status_code
 
-    assert r.json() == {
-        'name': network_name,
-        'node_count': len(node_table.get_rows()),
-        'edge_count': len(edge_table.get_rows()),
-        'id': INTEGER_ID_RE,
-        'created': TIMESTAMP_RE,
-        'modified': TIMESTAMP_RE,
-        'workspace': {
-            'id': workspace.pk,
-            'name': workspace.name,
+    if success:
+        assert r.json() == {
+            'name': network_name,
+            'node_count': len(node_table.get_rows()),
+            'edge_count': len(edge_table.get_rows()),
+            'id': INTEGER_ID_RE,
             'created': TIMESTAMP_RE,
             'modified': TIMESTAMP_RE,
-            'arango_db_name': workspace.arango_db_name,
-            'public': False,
-        },
-    }
+            'workspace': {
+                'id': workspace.pk,
+                'name': workspace.name,
+                'created': TIMESTAMP_RE,
+                'modified': TIMESTAMP_RE,
+                'arango_db_name': workspace.arango_db_name,
+                'public': False,
+            },
+        }
 
-    # Django will raise an exception if this fails, implicitly validating that the object exists
-    network: Network = Network.objects.get(name=network_name)
+        # Django will raise an exception if this fails, implicitly validating that the object exists
+        network: Network = Network.objects.get(name=network_name)
 
-    # Assert that object was created in arango
-    assert workspace.get_arango_db().has_graph(network.name)
-
-
-@pytest.mark.django_db
-def test_network_rest_create_forbidden(
-    workspace: Workspace,
-    user: User,
-    authenticated_api_client: APIClient,
-):
-    workspace.set_user_permission(user, WorkspaceRoleChoice.READER)
-    edge_table = populated_table(workspace, True)
-    network_name = 'network'
-    r = authenticated_api_client.post(
-        f'/api/workspaces/{workspace.name}/networks/',
-        {'name': network_name, 'edge_table': edge_table.name},
-        format='json',
-    )
-    assert r.status_code == 403
+        # Assert that object was created in arango
+        assert workspace.get_arango_db().has_graph(network.name)
 
 
 @pytest.mark.django_db
-def test_network_rest_create_no_access(
-    workspace: Workspace,
-    authenticated_api_client: APIClient,
-):
-    network_name = 'network'
-    edge_table = populated_table(workspace, True)
-    r = authenticated_api_client.post(
-        f'/api/workspaces/{workspace.name}/networks/',
-        {'name': network_name, 'edge_table': edge_table.name},
-        format='json',
-    )
-    assert r.status_code == 404
-
-
-@pytest.mark.django_db
-@pytest.mark.parametrize('permission', workspace_role_range())
+@pytest.mark.parametrize(
+    'permission,is_owner,status_code,success',
+    [
+        (None, False, 404, False),
+        (WorkspaceRoleChoice.READER, False, 200, True),
+        (WorkspaceRoleChoice.WRITER, False, 200, True),
+        (WorkspaceRoleChoice.MAINTAINER, False, 200, True),
+        (None, True, 200, True),
+    ],
+)
 def test_network_rest_retrieve(
     workspace: Workspace,
     user: User,
     authenticated_api_client: APIClient,
     permission: WorkspaceRoleChoice,
+    is_owner: bool,
+    status_code: int,
+    success: bool,
 ):
-    workspace.set_user_permission(user, permission)
+    if permission is not None:
+        workspace.set_user_permission(user, permission)
+    elif is_owner:
+        workspace.set_owner(user)
     network = populated_network(workspace)
 
-    assert authenticated_api_client.get(
-        f'/api/workspaces/{workspace.name}/networks/{network.name}/'
-    ).data == {
-        'id': network.pk,
-        'name': network.name,
-        'node_count': network.node_count,
-        'edge_count': network.edge_count,
-        'created': TIMESTAMP_RE,
-        'modified': TIMESTAMP_RE,
-        'workspace': {
-            'id': workspace.pk,
-            'name': workspace.name,
+    r = authenticated_api_client.get(f'/api/workspaces/{workspace.name}/networks/{network.name}/')
+    assert r.status_code == status_code
+
+    if success:
+        assert r.data == {
+            'id': network.pk,
+            'name': network.name,
+            'node_count': network.node_count,
+            'edge_count': network.edge_count,
             'created': TIMESTAMP_RE,
             'modified': TIMESTAMP_RE,
-            'arango_db_name': workspace.arango_db_name,
-            'public': False,
-        },
-    }
+            'workspace': {
+                'id': workspace.pk,
+                'name': workspace.name,
+                'created': TIMESTAMP_RE,
+                'modified': TIMESTAMP_RE,
+                'arango_db_name': workspace.arango_db_name,
+                'public': False,
+            },
+        }
 
 
 @pytest.mark.django_db
@@ -217,57 +216,45 @@ def test_network_rest_retrieve_public(public_workspace: Workspace, api_client: A
 
 
 @pytest.mark.django_db
-def test_network_rest_retrieve_no_access(workspace: Workspace, authenticated_api_client: APIClient):
-    network = populated_network(workspace)
-    r = authenticated_api_client.get(f'/api/workspaces/{workspace.name}/networks/{network.name}/')
-    assert r.status_code == 404
-
-
-@pytest.mark.django_db
 @pytest.mark.parametrize(
-    'permission',
-    workspace_role_range(min_role=WorkspaceRoleChoice.WRITER),
+    'permission,is_owner,status_code,success',
+    [
+        (None, False, 404, False),
+        (WorkspaceRoleChoice.READER, False, 403, False),
+        (WorkspaceRoleChoice.WRITER, False, 204, True),
+        (WorkspaceRoleChoice.MAINTAINER, False, 204, True),
+        (None, True, 204, True),
+    ],
 )
 def test_network_rest_delete(
     workspace: Workspace,
     user: User,
     authenticated_api_client: APIClient,
     permission: WorkspaceRoleChoice,
+    is_owner: bool,
+    status_code: int,
+    success: bool,
 ):
     """Tests deleting a network on a workspace for which the user is at least a writer."""
-    workspace.set_user_permission(user, permission)
+    if permission is not None:
+        workspace.set_user_permission(user, permission)
+    elif is_owner:
+        workspace.set_owner(user)
     network = populated_network(workspace)
-
     r = authenticated_api_client.delete(
         f'/api/workspaces/{workspace.name}/networks/{network.name}/'
     )
 
-    assert r.status_code == 204
+    assert r.status_code == status_code
 
-    # Assert relevant objects are deleted
-    assert not Network.objects.filter(name=workspace.name).exists()
-    assert not workspace.get_arango_db().has_graph(network.name)
-
-
-@pytest.mark.django_db
-def test_network_rest_delete_owned(
-    workspace: Workspace,
-    user: User,
-    authenticated_api_client: APIClient,
-):
-    """Tests deleting a network on a workspace for which the user is the owner."""
-    workspace.set_owner(user)
-    network = populated_network(workspace)
-
-    r = authenticated_api_client.delete(
-        f'/api/workspaces/{workspace.name}/networks/{network.name}/'
-    )
-
-    assert r.status_code == 204
-
-    # Assert relevant objects are deleted
-    assert not Network.objects.filter(name=workspace.name).exists()
-    assert not workspace.get_arango_db().has_graph(network.name)
+    if success:
+        # Assert relevant objects are deleted
+        assert not Network.objects.filter(name=network.name).exists()
+        assert not workspace.get_arango_db().has_graph(network.name)
+    else:
+        # Assert objects are not deleted
+        assert Network.objects.filter(name=network.name).exists()
+        assert workspace.get_arango_db().has_graph(network.name)
 
 
 @pytest.mark.django_db
@@ -285,125 +272,106 @@ def test_network_rest_delete_unauthorized(workspace: Workspace, api_client: APIC
 
 
 @pytest.mark.django_db
-def test_network_rest_delete_forbidden(
-    workspace: Workspace,
-    user: User,
-    network_factory: NetworkFactory,
-    authenticated_api_client: APIClient,
-):
-    """Tests deleting a network on a workspace without sufficient permissions."""
-    workspace.set_user_permission(user, WorkspaceRoleChoice.READER)
-    network: Table = network_factory(workspace=workspace)
-    r = authenticated_api_client.delete(
-        f'/api/workspaces/{workspace.name}/networks/{network.name}/'
-    )
-
-    assert r.status_code == 403
-
-    # Assert relevant objects are not deleted
-    assert Network.objects.filter(name=network.name).exists()
-    assert workspace.get_arango_db().has_graph(network.name)
-
-
-@pytest.mark.django_db
-def test_network_rest_delete_no_access(workspace: Workspace, authenticated_api_client: APIClient):
-    """Test deleting a network from a workspace for which the user has no access at all."""
-    network = populated_network(workspace)
-    r = authenticated_api_client.delete(
-        f'/api/workspaces/{workspace.name}/networks/{network.name}/'
-    )
-    assert r.status_code == 404
-
-    # Assert relevant objects are not deleted
-    assert Network.objects.filter(name=network.name).exists()
-    assert workspace.get_arango_db().has_graph(network.name)
-
-
-@pytest.mark.django_db
-@pytest.mark.parametrize('permission', workspace_role_range())
+@pytest.mark.parametrize(
+    'permission,is_owner,status_code,success',
+    [
+        (None, False, 404, False),
+        (WorkspaceRoleChoice.READER, False, 200, True),
+        (WorkspaceRoleChoice.WRITER, False, 200, True),
+        (WorkspaceRoleChoice.MAINTAINER, False, 200, True),
+        (None, True, 200, True),
+    ],
+)
 def test_network_rest_retrieve_nodes(
     workspace: Workspace,
     user: User,
     authenticated_api_client: APIClient,
     permission: WorkspaceRoleChoice,
+    is_owner: bool,
+    status_code: int,
+    success: bool,
 ):
-    workspace.set_user_permission(user, permission)
+    if permission is not None:
+        workspace.set_user_permission(user, permission)
+    elif is_owner:
+        workspace.set_owner(user)
     network = populated_network(workspace)
     nodes = list(network.nodes())
 
-    assert_limit_offset_results(
-        authenticated_api_client,
-        f'/api/workspaces/{workspace.name}/networks/{network.name}/nodes/',
-        nodes,
-    )
+    if success:
+        assert_limit_offset_results(
+            authenticated_api_client,
+            f'/api/workspaces/{workspace.name}/networks/{network.name}/nodes/',
+            nodes,
+        )
+    else:
+        r = r = authenticated_api_client.get(
+            f'/api/workspaces/{workspace.name}/networks/{network.name}/nodes/',
+            {'limit': 0, 'offset': 0},
+        )
+        assert r.status_code == status_code
 
 
 @pytest.mark.django_db
-def test_network_rest_retrieve_nodes_public(
-    public_workspace: Workspace, authenticated_api_client: APIClient
-):
+def test_network_rest_retrieve_nodes_public(public_workspace: Workspace, api_client: APIClient):
     network = populated_network(public_workspace)
     nodes = list(network.nodes())
 
     assert_limit_offset_results(
-        authenticated_api_client,
+        api_client,
         f'/api/workspaces/{public_workspace.name}/networks/{network.name}/nodes/',
         nodes,
     )
 
 
 @pytest.mark.django_db
-def test_network_rest_retrieve_nodes_no_access(
-    workspace: Workspace, authenticated_api_client: APIClient
-):
-    network = populated_network(workspace)
-    r = authenticated_api_client.get(
-        f'/api/workspaces/{workspace.name}/networks/{network.name}/nodes/',
-        {'limit': 0, 'offset': 0},
-    )
-    assert r.status_code == 404
-
-
-@pytest.mark.django_db
-@pytest.mark.parametrize('permission', workspace_role_range())
+@pytest.mark.parametrize(
+    'permission,is_owner,status_code,success',
+    [
+        (None, False, 404, False),
+        (WorkspaceRoleChoice.READER, False, 200, True),
+        (WorkspaceRoleChoice.WRITER, False, 200, True),
+        (WorkspaceRoleChoice.MAINTAINER, False, 200, True),
+        (None, True, 200, True),
+    ],
+)
 def test_network_rest_retrieve_edges(
     workspace: Workspace,
     user: User,
     authenticated_api_client: APIClient,
     permission: WorkspaceRoleChoice,
+    is_owner: bool,
+    status_code: int,
+    success: bool,
 ):
-    workspace.set_user_permission(user, permission)
+    if permission is not None:
+        workspace.set_user_permission(user, permission)
+    elif is_owner:
+        workspace.set_owner(user)
     network = populated_network(workspace)
     edges = list(network.edges())
 
-    assert_limit_offset_results(
-        authenticated_api_client,
-        f'/api/workspaces/{workspace.name}/networks/{network.name}/edges/',
-        edges,
-    )
+    if success:
+        assert_limit_offset_results(
+            authenticated_api_client,
+            f'/api/workspaces/{workspace.name}/networks/{network.name}/edges/',
+            edges,
+        )
+    else:
+        r = authenticated_api_client.get(
+            f'/api/workspaces/{workspace.name}/networks/{network.name}/edges/',
+            {'limit': 0, 'offset': 0},
+        )
+        assert r.status_code == 404
 
 
 @pytest.mark.django_db
-def test_network_rest_retrieve_edges_public(
-    public_workspace: Workspace, authenticated_api_client: APIClient
-):
+def test_network_rest_retrieve_edges_public(public_workspace: Workspace, api_client: APIClient):
     network = populated_network(public_workspace)
     edges = list(network.edges())
 
     assert_limit_offset_results(
-        authenticated_api_client,
+        api_client,
         f'/api/workspaces/{public_workspace.name}/networks/{network.name}/edges/',
         edges,
     )
-
-
-@pytest.mark.django_db
-def test_network_rest_retrieve_edges_no_access(
-    workspace: Workspace, authenticated_api_client: APIClient
-):
-    network = populated_network(workspace)
-    r = authenticated_api_client.get(
-        f'/api/workspaces/{workspace.name}/networks/{network.name}/edges/',
-        {'limit': 0, 'offset': 0},
-    )
-    assert r.status_code == 404

--- a/multinet/api/tests/test_upload_common.py
+++ b/multinet/api/tests/test_upload_common.py
@@ -8,63 +8,52 @@ from multinet.api.models.workspace import Workspace, WorkspaceRoleChoice
 from multinet.api.tests.factories import UploadFactory
 from multinet.api.tests.fuzzy import TIMESTAMP_RE, workspace_re
 
-from .utils import workspace_role_range
-
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('permission', workspace_role_range())
+@pytest.mark.parametrize(
+    'permission,is_owner,status_code,success',
+    [
+        (None, False, 404, False),
+        (WorkspaceRoleChoice.READER, False, 200, True),
+        (WorkspaceRoleChoice.WRITER, False, 200, True),
+        (WorkspaceRoleChoice.MAINTAINER, False, 200, True),
+        (None, True, 200, True),
+    ],
+)
 def test_upload_rest_retrieve(
     workspace: Workspace,
     user: User,
     upload_factory: UploadFactory,
     authenticated_api_client: APIClient,
     permission: WorkspaceRoleChoice,
+    is_owner: bool,
+    status_code: int,
+    success: bool,
 ):
-    """Test retrieval of an upload on a workspace for a user with read access."""
-    workspace.set_user_permission(user, permission)
+    """Test retrieval of an upload on a private workspace."""
+    if permission is not None:
+        workspace.set_user_permission(user, permission)
+    elif is_owner:
+        workspace.set_owner(user)
+
     upload: Upload = upload_factory(workspace=workspace, user=user)
     r: Response = authenticated_api_client.get(
         f'/api/workspaces/{workspace.name}/uploads/{upload.pk}/'
     )
-    assert r.status_code == 200
-    assert r.data == {
-        'id': upload.pk,
-        'blob': upload.blob,
-        'user': user.username,
-        'created': TIMESTAMP_RE,
-        'modified': TIMESTAMP_RE,
-        'error_messages': upload.error_messages,
-        'data_type': upload.data_type,
-        'status': upload.status,
-        'workspace': workspace_re(workspace),
-    }
+    assert r.status_code == status_code
 
-
-@pytest.mark.django_db
-def test_upload_rest_retrieve_owned(
-    workspace: Workspace,
-    user: User,
-    upload_factory: UploadFactory,
-    authenticated_api_client: APIClient,
-):
-    """Test retrieval of an upload on a workspace for the owner."""
-    workspace.set_owner(user)
-    upload: Upload = upload_factory(workspace=workspace, user=user)
-    r: Response = authenticated_api_client.get(
-        f'/api/workspaces/{workspace.name}/uploads/{upload.pk}/'
-    )
-    assert r.status_code == 200
-    assert r.data == {
-        'id': upload.pk,
-        'blob': upload.blob,
-        'user': user.username,
-        'created': TIMESTAMP_RE,
-        'modified': TIMESTAMP_RE,
-        'error_messages': upload.error_messages,
-        'data_type': upload.data_type,
-        'status': upload.status,
-        'workspace': workspace_re(workspace),
-    }
+    if success:
+        assert r.data == {
+            'id': upload.pk,
+            'blob': upload.blob,
+            'user': user.username,
+            'created': TIMESTAMP_RE,
+            'modified': TIMESTAMP_RE,
+            'error_messages': upload.error_messages,
+            'data_type': upload.data_type,
+            'status': upload.status,
+            'workspace': workspace_re(workspace),
+        }
 
 
 @pytest.mark.django_db
@@ -74,7 +63,7 @@ def test_upload_rest_retrieve_public(
     upload_factory: UploadFactory,
     api_client: APIClient,
 ):
-    """Test retrieval of an upload on a public workspace for which the user has no permission."""
+    """Test retrieval of an upload on a public workspace for an unauthorized user."""
     upload = upload_factory(workspace=public_workspace, user=user)
     r: Response = api_client.get(f'/api/workspaces/{public_workspace.name}/uploads/{upload.pk}/')
     assert r.status_code == 200
@@ -92,38 +81,41 @@ def test_upload_rest_retrieve_public(
 
 
 @pytest.mark.django_db
-def test_upload_rest_retrieve_private(
-    workspace: Workspace,
-    user: User,
-    upload_factory: UploadFactory,
-    authenticated_api_client: APIClient,
-):
-    """Test retrieval of an upload on a workspace for which the user has no permission."""
-    upload = upload_factory(workspace=workspace, user=user)
-    r: Response = authenticated_api_client.get(
-        f'/api/workspaces/{workspace.name}/uploads/{upload.pk}/'
-    )
-    assert r.status_code == 404
-
-
-@pytest.mark.django_db
-@pytest.mark.parametrize('permission', workspace_role_range())
+@pytest.mark.parametrize(
+    'permission,is_owner,status_code,success',
+    [
+        (None, False, 404, False),
+        (WorkspaceRoleChoice.READER, False, 200, True),
+        (WorkspaceRoleChoice.WRITER, False, 200, True),
+        (WorkspaceRoleChoice.MAINTAINER, False, 200, True),
+        (None, True, 200, True),
+    ],
+)
 def test_upload_rest_list(
     workspace: Workspace,
     user: User,
     upload_factory: UploadFactory,
     authenticated_api_client: APIClient,
     permission: WorkspaceRoleChoice,
+    is_owner: bool,
+    status_code: int,
+    success: bool,
 ):
     """Test listing all uploads on a workspace for which the user has permission."""
-    workspace.set_user_permission(user, permission)
+    if permission is not None:
+        workspace.set_user_permission(user, permission)
+    elif is_owner:
+        workspace.set_owner(user)
+
     upload_ids = [upload_factory(workspace=workspace, user=user).pk for _ in range(3)]
     r: Response = authenticated_api_client.get(f'/api/workspaces/{workspace.name}/uploads/')
-    r_json = r.json()
+    assert r.status_code == status_code
 
-    assert r_json['count'] == len(upload_ids)
-    for upload in r_json['results']:
-        assert upload['id'] in upload_ids
+    if success:
+        r_json = r.json()
+        assert r_json['count'] == len(upload_ids)
+        for upload in r_json['results']:
+            assert upload['id'] in upload_ids
 
 
 @pytest.mark.django_db
@@ -133,7 +125,7 @@ def test_upload_rest_list_public(
     upload_factory: UploadFactory,
     api_client: APIClient,
 ):
-    """Test listing all uploads on a public workspace for which the user has no permission."""
+    """Test listing all uploads on a public workspace with an unauthorized user."""
     upload_ids = [upload_factory(workspace=public_workspace, user=user).pk for _ in range(3)]
     r: Response = api_client.get(f'/api/workspaces/{public_workspace.name}/uploads/')
     r_json = r.json()
@@ -141,18 +133,3 @@ def test_upload_rest_list_public(
     assert r_json['count'] == len(upload_ids)
     for upload in r_json['results']:
         assert upload['id'] in upload_ids
-
-
-@pytest.mark.django_db
-def test_upload_rest_list_private(
-    workspace: Workspace,
-    user: User,
-    upload_factory: UploadFactory,
-    authenticated_api_client: APIClient,
-):
-    """Test listing all uploads on a private workspace for which the user has no permission."""
-    for _ in range(3):
-        upload_factory(workspace=workspace, user=user)
-    r: Response = authenticated_api_client.get(f'/api/workspaces/{workspace.name}/uploads/')
-
-    assert r.status_code == 404

--- a/multinet/api/tests/test_upload_common.py
+++ b/multinet/api/tests/test_upload_common.py
@@ -54,6 +54,8 @@ def test_upload_rest_retrieve(
             'status': upload.status,
             'workspace': workspace_re(workspace),
         }
+    else:
+        assert r.data == {'detail': 'Not found.'}
 
 
 @pytest.mark.django_db
@@ -116,6 +118,8 @@ def test_upload_rest_list(
         assert r_json['count'] == len(upload_ids)
         for upload in r_json['results']:
             assert upload['id'] in upload_ids
+    else:
+        assert r.data == {'detail': 'Not found.'}
 
 
 @pytest.mark.django_db

--- a/multinet/api/tests/test_workspace.py
+++ b/multinet/api/tests/test_workspace.py
@@ -77,7 +77,7 @@ def test_workspace_rest_create(authenticated_api_client: APIClient):
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    "permission,is_owner,status_code,success",
+    'permission,is_owner,status_code,success',
     [
         (None, False, 404, False),
         (WorkspaceRoleChoice.READER, False, 200, True),
@@ -132,7 +132,7 @@ def test_workspace_rest_retrieve_public(
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    "permission,is_owner,status_code,success",
+    'permission,is_owner,status_code,success',
     [
         (None, False, 404, False),
         (WorkspaceRoleChoice.READER, False, 403, False),
@@ -185,7 +185,7 @@ def test_workspace_rest_delete_unauthorized(
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    "permission,is_owner,status_code,success",
+    'permission,is_owner,status_code,success',
     [
         (None, False, 404, False),
         (WorkspaceRoleChoice.READER, False, 403, False),
@@ -231,7 +231,7 @@ def test_workspace_rest_get_permissions(
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    "permission,is_owner,status_code,success",
+    'permission,is_owner,status_code,success',
     [
         (None, False, 404, False),
         (WorkspaceRoleChoice.READER, False, 403, False),

--- a/multinet/api/tests/test_workspace.py
+++ b/multinet/api/tests/test_workspace.py
@@ -35,12 +35,19 @@ def test_workspace_rest_list(
         public_workspace_factory(name=fake.pystr()).name for _ in range(3)
     ]
     private_workspaces: List[Workspace] = [
-        private_workspace_factory(name=fake.pystr()) for _ in range(3)
+        private_workspace_factory(name=fake.pystr()) for _ in range(5)
     ]
 
     private_workspaces[0].set_user_permission(user, WorkspaceRoleChoice.READER)
-    private_workspaces[1].set_user_permission(user, WorkspaceRoleChoice.READER)
-    accessible_workspace_names += [private_workspaces[0].name, private_workspaces[1].name]
+    private_workspaces[1].set_user_permission(user, WorkspaceRoleChoice.WRITER)
+    private_workspaces[2].set_user_permission(user, WorkspaceRoleChoice.MAINTAINER)
+    private_workspaces[3].set_owner(user)
+    accessible_workspace_names += [
+        private_workspaces[0].name,
+        private_workspaces[1].name,
+        private_workspaces[2].name,
+        private_workspaces[3].name,
+    ]
 
     r = authenticated_api_client.get('/api/workspaces/')
     r_json = r.json()
@@ -69,18 +76,42 @@ def test_workspace_rest_create(authenticated_api_client: APIClient):
 
 
 @pytest.mark.django_db
-def test_workspace_rest_retrieve_owned(
-    workspace: Workspace, user: User, authenticated_api_client: APIClient
+@pytest.mark.parametrize(
+    "permission,is_owner,status_code,success",
+    [
+        (None, False, 404, False),
+        (WorkspaceRoleChoice.READER, False, 200, True),
+        (WorkspaceRoleChoice.WRITER, False, 200, True),
+        (WorkspaceRoleChoice.MAINTAINER, False, 200, True),
+        (None, True, 200, True),
+    ],
+)
+def test_workspace_rest_retrieve(
+    workspace: Workspace,
+    user: User,
+    authenticated_api_client: APIClient,
+    permission: WorkspaceRoleChoice,
+    is_owner: bool,
+    status_code: int,
+    success: bool,
 ):
-    workspace.set_owner(user)
-    assert authenticated_api_client.get(f'/api/workspaces/{workspace.name}/').data == {
-        'id': workspace.pk,
-        'name': workspace.name,
-        'created': TIMESTAMP_RE,
-        'modified': TIMESTAMP_RE,
-        'arango_db_name': workspace.arango_db_name,
-        'public': False,
-    }
+    if permission is not None:
+        workspace.set_user_permission(user, permission)
+    elif is_owner:
+        workspace.set_owner(user)
+
+    r = authenticated_api_client.get(f'/api/workspaces/{workspace.name}/')
+
+    assert r.status_code == status_code
+    if success:
+        assert r.data == {
+            'id': workspace.pk,
+            'name': workspace.name,
+            'created': TIMESTAMP_RE,
+            'modified': TIMESTAMP_RE,
+            'arango_db_name': workspace.arango_db_name,
+            'public': False,
+        }
 
 
 @pytest.mark.django_db
@@ -100,27 +131,41 @@ def test_workspace_rest_retrieve_public(
 
 
 @pytest.mark.django_db
-def test_workspace_rest_retrieve_no_access(
-    workspace: Workspace, authenticated_api_client: APIClient
-):
-    response = authenticated_api_client.get(f'/api/workspaces/{workspace.name}/')
-
-    # a user should not be able to know about a workspace they can't access
-    assert response.status_code == 404
-
-
-@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "permission,is_owner,status_code,success",
+    [
+        (None, False, 404, False),
+        (WorkspaceRoleChoice.READER, False, 403, False),
+        (WorkspaceRoleChoice.WRITER, False, 403, False),
+        (WorkspaceRoleChoice.MAINTAINER, False, 403, False),
+        (None, True, 204, True),
+    ],
+)
 def test_workspace_rest_delete(
-    workspace: Workspace, user: User, authenticated_api_client: APIClient
+    workspace: Workspace,
+    user: User,
+    authenticated_api_client: APIClient,
+    permission: WorkspaceRoleChoice,
+    is_owner: bool,
+    status_code: int,
+    success: bool,
 ):
-    workspace.set_owner(user)
+    if permission is not None:
+        workspace.set_user_permission(user, permission)
+    elif is_owner:
+        workspace.set_owner(user)
     r = authenticated_api_client.delete(f'/api/workspaces/{workspace.name}/')
 
-    assert r.status_code == 204
+    assert r.status_code == status_code
 
-    # Assert relevant objects are deleted
-    assert not Workspace.objects.filter(name=workspace.name).exists()
-    assert not arango_system_db().has_database(workspace.arango_db_name)
+    if success:
+        # Assert relevant objects are deleted
+        assert not Workspace.objects.filter(name=workspace.name).exists()
+        assert not arango_system_db().has_database(workspace.arango_db_name)
+    else:
+        # Assert objecsts are not deleted
+        assert Workspace.objects.filter(name=workspace.name).exists()
+        assert arango_system_db().has_database(workspace.arango_db_name)
 
 
 @pytest.mark.django_db
@@ -139,154 +184,78 @@ def test_workspace_rest_delete_unauthorized(
 
 
 @pytest.mark.django_db
-def test_workspace_rest_delete_forbidden(
-    workspace: Workspace,
-    user: User,
-    authenticated_api_client: APIClient,
-):
-    workspace.set_user_permission(user, WorkspaceRoleChoice.READER)
-    response = authenticated_api_client.delete(f'/api/workspaces/{workspace.name}/')
-    assert response.status_code == 403
-
-    # Assert relevant objects are not deleted
-    assert Workspace.objects.filter(name=workspace.name).exists()
-    assert arango_system_db().has_database(workspace.arango_db_name)
-
-
-@pytest.mark.django_db
-def test_workspace_rest_delete_no_access(
-    private_workspace_factory: PrivateWorkspaceFactory,
-    authenticated_api_client: APIClient,
-):
-    # Create workspace this way, so the authenticated user has no access
-    workspace: Workspace = private_workspace_factory()
-    r = authenticated_api_client.delete(f'/api/workspaces/{workspace.name}/')
-
-    # Without any access, don't reveal that this workspace exists at all
-    assert r.status_code == 404
-
-    # Assert relevant objects are not deleted
-    assert Workspace.objects.filter(name=workspace.name).exists()
-    assert arango_system_db().has_database(workspace.arango_db_name)
-
-
-@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "permission,is_owner,status_code,success",
+    [
+        (None, False, 404, False),
+        (WorkspaceRoleChoice.READER, False, 403, False),
+        (WorkspaceRoleChoice.WRITER, False, 403, False),
+        (WorkspaceRoleChoice.MAINTAINER, False, 200, True),
+        (None, True, 200, True),
+    ],
+)
 def test_workspace_rest_get_permissions(
     workspace: Workspace,
     user: User,
     user_factory: UserFactory,
     authenticated_api_client: APIClient,
+    permission: WorkspaceRoleChoice,
+    is_owner: bool,
+    status_code: int,
+    success: bool,
 ):
-    workspace.set_user_permission(user, WorkspaceRoleChoice.MAINTAINER)
-    workspace.set_owner(user_factory())
+    if permission is not None:
+        workspace.set_user_permission(user, permission)
+        workspace.set_owner(user_factory())
+    elif is_owner:
+        workspace.set_owner(user)
     create_users_with_permissions(user_factory, workspace)
     maintainer_names = [maintainer.username for maintainer in workspace.maintainers]
     writer_names = [writer.username for writer in workspace.writers]
     reader_names = [reader.username for reader in workspace.readers]
 
     r = authenticated_api_client.get(f'/api/workspaces/{workspace.name}/permissions/')
-    r_json = r.json()
+    assert r.status_code == status_code
 
-    assert r.status_code == 200
-    assert r_json['public'] == workspace.public
-    assert r_json['owner']['username'] == workspace.owner.username
+    if success:
+        r_json = r.json()
+        assert r_json['public'] == workspace.public
+        assert r_json['owner']['username'] == workspace.owner.username
 
-    assert all(maintainer['username'] in maintainer_names for maintainer in r_json['maintainers'])
-    assert all(writer['username'] in writer_names for writer in r_json['writers'])
-    assert all(reader['username'] in reader_names for reader in r_json['readers'])
+        assert all(
+            maintainer['username'] in maintainer_names for maintainer in r_json['maintainers']
+        )
+        assert all(writer['username'] in writer_names for writer in r_json['writers'])
+        assert all(reader['username'] in reader_names for reader in r_json['readers'])
 
 
 @pytest.mark.django_db
-def test_workspace_rest_get_permissions_owner(
+@pytest.mark.parametrize(
+    "permission,is_owner,status_code,success",
+    [
+        (None, False, 404, False),
+        (WorkspaceRoleChoice.READER, False, 403, False),
+        (WorkspaceRoleChoice.WRITER, False, 403, False),
+        (WorkspaceRoleChoice.MAINTAINER, False, 200, True),
+        (None, True, 200, True),
+    ],
+)
+def test_workspace_rest_put_permissions(
     workspace: Workspace,
     user: User,
     user_factory: UserFactory,
-    authenticated_api_client: APIClient,
-):
-    workspace.set_owner(user)
-    create_users_with_permissions(user_factory, workspace)
-    maintainer_names = [maintainer.username for maintainer in workspace.maintainers]
-    writer_names = [writer.username for writer in workspace.writers]
-    reader_names = [reader.username for reader in workspace.readers]
-
-    r = authenticated_api_client.get(f'/api/workspaces/{workspace.name}/permissions/')
-    r_json = r.json()
-
-    assert r.status_code == 200
-    assert r_json['public'] == workspace.public
-    assert r_json['owner']['username'] == workspace.owner.username
-
-    assert all(maintainer['username'] in maintainer_names for maintainer in r_json['maintainers'])
-    assert all(writer['username'] in writer_names for writer in r_json['writers'])
-    assert all(reader['username'] in reader_names for reader in r_json['readers'])
-
-
-@pytest.mark.django_db
-@pytest.mark.parametrize('permission', [WorkspaceRoleChoice.READER, WorkspaceRoleChoice.WRITER])
-def test_workspace_rest_get_permissions_forbidden(
-    workspace: Workspace,
-    user: User,
     authenticated_api_client: APIClient,
     permission: WorkspaceRoleChoice,
+    is_owner: bool,
+    status_code: int,
+    success: bool,
 ):
-    workspace.set_user_permission(user, permission)
-    r = authenticated_api_client.get(f'/api/workspaces/{workspace.name}/permissions/')
-    assert r.status_code == 403
-
-
-@pytest.mark.django_db
-def test_workspace_rest_get_permissions_no_access(
-    workspace: Workspace, authenticated_api_client: APIClient
-):
-    r = authenticated_api_client.get(f'/api/workspaces/{workspace.name}/permissions/')
-    assert r.status_code == 404
-
-
-@pytest.mark.django_db
-def test_workspace_rest_put_permissions_owner(
-    workspace: Workspace,
-    user: User,
-    user_factory: UserFactory,
-    authenticated_api_client: APIClient,
-):
-    workspace.set_owner(user)
-    new_owner = user_factory()
-    new_maintainers: List[Dict] = [{'username': user_factory().username} for _ in range(2)]
-    new_writers: List[Dict] = [{'username': user_factory().username} for _ in range(2)]
-    new_readers: List[Dict] = [{'username': user_factory().username} for _ in range(2)]
-    request_data = {
-        'public': True,
-        'owner': {'username': new_owner.username},
-        'maintainers': new_maintainers,
-        'writers': new_writers,
-        'readers': new_readers,
-    }
-    r = authenticated_api_client.put(
-        f'/api/workspaces/{workspace.name}/permissions/', request_data, format='json'
-    )
-    workspace = Workspace.objects.get(id=workspace.pk)
-
-    assert r.status_code == 200
-    assert workspace.public == request_data['public']
-    assert workspace.owner == new_owner
-
-    readers_names = [reader['username'] for reader in new_readers]
-    writers_names = [writer['username'] for writer in new_writers]
-    maintainers_names = [maintainer['username'] for maintainer in new_maintainers]
-    assert all([reader.username in readers_names for reader in workspace.readers])
-    assert all([writer.username in writers_names for writer in workspace.writers])
-    assert all([maintainer.username in maintainers_names for maintainer in workspace.maintainers])
-
-
-@pytest.mark.django_db
-def test_workspace_rest_put_permissions_maintainer(
-    workspace: Workspace,
-    user: User,
-    user_factory: UserFactory,
-    authenticated_api_client: APIClient,
-):
-    workspace.set_user_permission(user, WorkspaceRoleChoice.MAINTAINER)
     old_owner = workspace.owner
+    if permission is not None:
+        workspace.set_user_permission(user, permission)
+    elif is_owner:
+        workspace.set_owner(user)
+
     new_owner = user_factory()
     new_maintainers: List[Dict] = [{'username': user_factory().username} for _ in range(2)]
     new_writers: List[Dict] = [{'username': user_factory().username} for _ in range(2)]
@@ -301,64 +270,26 @@ def test_workspace_rest_put_permissions_maintainer(
     r = authenticated_api_client.put(
         f'/api/workspaces/{workspace.name}/permissions/', request_data, format='json'
     )
-    r_json = r.json()
-    assert r.status_code == 200
-    assert r_json['public'] == request_data['public']
-    # maintainers cannot set the owner of a workspace
-    assert workspace.owner == old_owner
-
-    readers_names = [reader['username'] for reader in new_readers]
-    writers_names = [writer['username'] for writer in new_writers]
-    maintainers_names = [maintainer['username'] for maintainer in new_maintainers]
-    assert all([reader.username in readers_names for reader in workspace.readers])
-    assert all([writer.username in writers_names for writer in workspace.writers])
-    assert all([maintainer.username in maintainers_names for maintainer in workspace.maintainers])
-
-
-@pytest.mark.django_db
-@pytest.mark.parametrize('permission', [WorkspaceRoleChoice.READER, WorkspaceRoleChoice.WRITER])
-def test_workspace_rest_put_permissions_forbidden(
-    workspace: Workspace,
-    user: User,
-    user_factory: UserFactory,
-    authenticated_api_client: APIClient,
-    permission: WorkspaceRoleChoice,
-):
-    workspace.set_user_permission(user, permission)
-    new_owner = user_factory()
-    new_maintainers: List[Dict] = [{'username': user_factory().username} for _ in range(2)]
-    public = not workspace.public
-    request_data = {
-        'public': public,
-        'owner': {'username': new_owner.username},
-        'maintainers': new_maintainers,
-        'writers': [],
-        'readers': [],
-    }
-    r = authenticated_api_client.put(
-        f'/api/workspaces/{workspace.name}/permissions/', request_data, format='json'
-    )
-
-    assert r.status_code == 403
-    assert workspace.owner != new_owner
-    assert len(list(workspace.maintainers)) == 0
-
-
-@pytest.mark.django_db
-def test_workspace_rest_put_permissions_no_access(
-    workspace: Workspace, user: User, authenticated_api_client: APIClient
-):
-    request_data = {
-        'public': not workspace.public,
-        'owner': {'username': user.username},
-        'maintainers': [],
-        'writers': [],
-        'readers': [],
-    }
-    r = authenticated_api_client.put(
-        f'/api/workspaces/{workspace.name}/permissions/', request_data, format='json'
-    )
     workspace = Workspace.objects.get(id=workspace.pk)
-    assert r.status_code == 404
-    assert workspace.public != request_data['public']
-    assert workspace.owner != user
+
+    assert r.status_code == status_code
+
+    if success:
+        assert workspace.public == request_data['public']
+
+        if is_owner:
+            assert workspace.owner == new_owner
+        else:
+            assert workspace.owner == old_owner
+
+        readers_names = [reader['username'] for reader in new_readers]
+        writers_names = [writer['username'] for writer in new_writers]
+        maintainers_names = [maintainer['username'] for maintainer in new_maintainers]
+        assert all([reader.username in readers_names for reader in workspace.readers])
+        assert all([writer.username in writers_names for writer in workspace.writers])
+        assert all(
+            [maintainer.username in maintainers_names for maintainer in workspace.maintainers]
+        )
+    else:
+        assert workspace.public is False
+        assert workspace.owner == old_owner

--- a/multinet/api/tests/utils.py
+++ b/multinet/api/tests/utils.py
@@ -7,12 +7,6 @@ from multinet.api.models import Workspace, WorkspaceRoleChoice
 from multinet.api.tests.factories import UserFactory
 
 
-def workspace_role_range(
-    min_role=WorkspaceRoleChoice.READER, max_role=WorkspaceRoleChoice.MAINTAINER
-):
-    return [choice for choice in WorkspaceRoleChoice if min_role <= choice <= max_role]
-
-
 def create_users_with_permissions(user_factory: UserFactory, workspace: Workspace, num_users=3):
     for permission in [
         WorkspaceRoleChoice.READER,


### PR DESCRIPTION
Closes #56 

This PR leverages `pytest`'s ability to parametrize tests. We can reduce the number of test functions written for our API endpoints while increasing the number of test cases to include all permission levels. 

This PR makes the following changes:

1. Use `@pytest.mark.parametrize(<args>, [<values>])` to define how arguments to test functions should change with test cases on API endpoints that require similar set ups
2. Removal of test functions made redundant by no. 1
3. Removal of now-unnecessary helper function to generate a range of workspace permissions
4. Change our factory boy factories to use `LazyAttribute` over `SubFactory` to reduce coupling between our `pytest` fixtures