### PR TITLE
Return distinct workspaces from get_queryset

### DIFF
--- a/multinet/api/models/workspace.py
+++ b/multinet/api/models/workspace.py
@@ -108,19 +108,27 @@ class Workspace(TimeStampedModel):
         self.save()
 
     def set_user_permissions_bulk(
-        self, readers: List[User], writers: List[User], maintainers: List[User]
+        self,
+        readers: Optional[List[User]] = None,
+        writers: Optional[List[User]] = None,
+        maintainers: Optional[List[User]] = None,
     ):
         """Replace all existing permissions on this workspace."""
         WorkspaceRole.objects.filter(workspace=self).delete()
 
+        readers = readers or []
         new_reader_roles = [
             WorkspaceRole(workspace=self, user=user, role=WorkspaceRoleChoice.READER)
             for user in readers
         ]
+
+        writers = writers or []
         new_writer_roles = [
             WorkspaceRole(workspace=self, user=user, role=WorkspaceRoleChoice.WRITER)
             for user in writers
         ]
+
+        maintainers = maintainers or []
         new_maintainer_roles = [
             WorkspaceRole(workspace=self, user=user, role=WorkspaceRoleChoice.MAINTAINER)
             for user in maintainers

--- a/multinet/api/tests/test_workspace.py
+++ b/multinet/api/tests/test_workspace.py
@@ -14,7 +14,7 @@ from multinet.api.tests.factories import (
 from multinet.api.tests.utils import create_users_with_permissions
 from multinet.api.utils.arango import arango_system_db
 
-from .fuzzy import TIMESTAMP_RE
+from .fuzzy import TIMESTAMP_RE, workspace_re
 
 
 @pytest.mark.django_db
@@ -51,6 +51,30 @@ def test_workspace_rest_list(
     for workspace in r_json['results']:
         assert workspace['name'] in accessible_workspace_names
         assert sysdb.has_database(workspace['arango_db_name'])
+
+
+@pytest.mark.django_db
+def test_workspace_rest_list_no_duplicates(
+    workspace: Workspace,
+    user_factory: UserFactory,
+    user: User,
+    authenticated_api_client: APIClient,
+):
+    """Test that multiple roles on a workspace results in no duplicates."""
+    # Set authenticated user as owner
+    workspace.set_owner(user)
+
+    # Give multiple users permissions on the workspace
+    workspace.set_user_permissions_bulk(readers=[user_factory() for _ in range(5)])
+
+    # Test that there's only one copy of this workspace returned
+    r = authenticated_api_client.get('/api/workspaces/')
+    assert r.json() == {
+        'count': 1,
+        'next': None,
+        'previous': None,
+        'results': [workspace_re(workspace)],
+    }
 
 
 @pytest.mark.django_db

--- a/multinet/api/views/workspace.py
+++ b/multinet/api/views/workspace.py
@@ -52,7 +52,7 @@ class WorkspaceViewSet(ReadOnlyModelViewSet):
         public_workspaces = Q(public=True)
         return self.queryset.filter(
             public_workspaces | readable_private_workspaces | owned_workspaces
-        )
+        ).distinct()
 
     @swagger_auto_schema(
         request_body=WorkspaceCreateSerializer(),


### PR DESCRIPTION
Fixes #65

The issue is that there are multiple `WorkspaceRole` entries which correspond to the same workspace. Because of how Postgres joins these tables during the query, the same workspace can be returned multiple times. [Here](https://stackoverflow.com/questions/35823197/why-does-q-object-return-duplicated-results) is a stackoverflow thread about this.

The solution is to use the [`distinct`](https://docs.djangoproject.com/en/3.2/ref/models/querysets/#distinct) queryset method, to eliminate these duplicates.