### PR TITLE
Return both permission level and label from user permissions endpoint

### DIFF
--- a/multinet/api/tests/test_workspace.py
+++ b/multinet/api/tests/test_workspace.py
@@ -393,10 +393,12 @@ def test_workspace_rest_get_user_permission(
     assert r.status_code == status_code
 
     if success:
+        permission, permission_label = workspace.get_user_permission_tuple(user)
         assert r.data == {
             'username': user.username,
             'workspace': workspace.name,
-            'permission': workspace.get_user_permission_label(user),
+            'permission': permission,
+            'permission_label': permission_label,
         }
 
 
@@ -410,5 +412,6 @@ def test_workspace_rest_get_user_permission_public(
     assert r.data == {
         'username': '',  # anonymous user
         'workspace': workspace.name,
-        'permission': WorkspaceRoleChoice.READER.label,
+        'permission': WorkspaceRoleChoice.READER.value,
+        'permission_label': WorkspaceRoleChoice.READER.label,
     }

--- a/multinet/api/views/serializers.py
+++ b/multinet/api/views/serializers.py
@@ -84,7 +84,8 @@ class SingleUserWorkspacePermissionSerializer(serializers.Serializer):
     # Allow empty username since anonymous user is a reader for public workspaces
     username = serializers.CharField(validators=[UnicodeUsernameValidator()], allow_blank=True)
     workspace = serializers.CharField()
-    permission = serializers.CharField(allow_blank=True, allow_null=True)
+    permission = serializers.IntegerField(allow_null=True)
+    permission_label = serializers.CharField(allow_null=True)
 
 
 # The required fields for table creation

--- a/multinet/api/views/workspace.py
+++ b/multinet/api/views/workspace.py
@@ -132,9 +132,14 @@ class WorkspaceViewSet(ReadOnlyModelViewSet):
         """Get the workspace permission for the user of the request."""
         workspace: Workspace = get_object_or_404(Workspace, name=name)
         user = request.user
-        permission = workspace.get_user_permission_label(user)
+        permission, permission_label = workspace.get_user_permission_tuple(user)
+        data = {
+            'username': user.username,
+            'workspace': name,
+            'permission': permission,
+            'permission_label': permission_label,
+        }
 
-        data = {'username': user.username, 'workspace': name, 'permission': permission}
         serializer = SingleUserWorkspacePermissionSerializer(data=data)
         serializer.is_valid(raise_exception=True)
         return Response(serializer.data, status=status.HTTP_200_OK)

--- a/multinet/api/views/workspace.py
+++ b/multinet/api/views/workspace.py
@@ -25,6 +25,21 @@ from multinet.auth.decorators import require_workspace_ownership, require_worksp
 from .common import MultinetPagination
 
 
+def build_user_list(validated_data: OrderedDict) -> list:
+    """
+    Build a list of user objects from an ordered dictionary of user data.
+
+    Accepts an ordered dictionary containing a list of validated user data, e.g.
+    as a result of validating a PermissionsSerializer with request data.
+    Returns a list of user objects.
+    """
+    user_list = []
+    for valid_user in validated_data:
+        user_object = get_object_or_404(User, username=valid_user['username'])
+        user_list.append(user_object)
+    return user_list
+
+
 class WorkspaceViewSet(ReadOnlyModelViewSet):
     queryset = Workspace.objects.select_related('owner').all()
     lookup_field = 'name'
@@ -124,20 +139,6 @@ class WorkspaceViewSet(ReadOnlyModelViewSet):
         serializer.is_valid(raise_exception=True)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
-    def build_user_list(self, validated_data: OrderedDict) -> list:
-        """
-        Build a list of user objects from an ordered dictionary of user data.
-
-        Accepts an ordered dictionary containing a list of validated user data, e.g.
-        as a result of validating a PermissionsSerializer with request data.
-        Returns a list of user objects.
-        """
-        user_list = []
-        for valid_user in validated_data:
-            user_object = get_object_or_404(User, username=valid_user['username'])
-            user_list.append(user_object)
-        return user_list
-
     @swagger_auto_schema(
         request_body=PermissionsCreateSerializer(), responses={200: PermissionsReturnSerializer()}
     )
@@ -154,9 +155,9 @@ class WorkspaceViewSet(ReadOnlyModelViewSet):
         workspace.public = validated_data['public']
         workspace.save()
 
-        new_readers = self.build_user_list(validated_data['readers'])
-        new_writers = self.build_user_list(validated_data['writers'])
-        new_maintainers = self.build_user_list(validated_data['maintainers'])
+        new_readers = build_user_list(validated_data['readers'])
+        new_writers = build_user_list(validated_data['writers'])
+        new_maintainers = build_user_list(validated_data['maintainers'])
         workspace.set_user_permissions_bulk(
             readers=new_readers, writers=new_writers, maintainers=new_maintainers
         )


### PR DESCRIPTION
After seeing our use of #67 in https://github.com/multinet-app/multinet-client/pull/192, I realized it's cumbersome to not return the integer permission level itself from the the API, as we'll just need to reconstruct it on the client anyway. This PR amends that to return both the level itself and the associated label, returning `null` for both if they don't exist.

I think this will make the use of it much easier on the client, in particular removing the need for code like [this](https://github.com/multinet-app/multinet-client/blob/1d2aad1ad0824e67777b8dde8b57f99e6990629d/src/utils/permissions.ts#L4-L17). @naglepuff lmk what you think.