### PR TITLE
Fix use of serializers in get requests

### DIFF
--- a/multinet/api/views/common.py
+++ b/multinet/api/views/common.py
@@ -3,7 +3,6 @@ from typing import Dict, List
 from arango.cursor import Cursor
 from django.http.response import Http404
 from django.shortcuts import get_object_or_404
-from drf_yasg import openapi
 from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.request import Request
 from rest_framework_extensions.mixins import NestedViewSetMixin
@@ -14,28 +13,6 @@ from multinet.api.utils.arango import ArangoQuery
 
 class MultinetPagination(LimitOffsetPagination):
     default_limit = 100
-
-
-ARRAY_OF_OBJECTS_SCHEMA = openapi.Schema(
-    type=openapi.TYPE_ARRAY, items=openapi.Schema(type=openapi.TYPE_OBJECT)
-)
-
-
-LIMIT_OFFSET_QUERY_PARAMS = [
-    openapi.Parameter('limit', 'query', type='integer'),
-    openapi.Parameter('offset', 'query', type='integer'),
-]
-
-PAGINATED_RESULTS_SCHEMA = openapi.Schema(
-    type=openapi.TYPE_OBJECT,
-    required=['count', 'results'],
-    properties={
-        'count': openapi.Schema(type=openapi.TYPE_INTEGER),
-        'next': openapi.Schema(type=openapi.TYPE_STRING, format='uri', x_nullable=True),
-        'previous': openapi.Schema(type=openapi.TYPE_STRING, format='uri', x_nullable=True),
-        'results': ARRAY_OF_OBJECTS_SCHEMA,
-    },
-)
 
 
 class ArangoPagination(LimitOffsetPagination):

--- a/multinet/api/views/network.py
+++ b/multinet/api/views/network.py
@@ -1,7 +1,6 @@
 from typing import List, Optional
 
 from django.shortcuts import get_object_or_404
-from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import serializers, status
 from rest_framework.decorators import action
@@ -14,29 +13,15 @@ from multinet.api.auth.decorators import require_workspace_permission
 from multinet.api.models import Network, Table, Workspace, WorkspaceRoleChoice
 from multinet.api.utils.arango import ArangoQuery
 from multinet.api.views.serializers import (
+    LimitOffsetSerializer,
     NetworkCreateSerializer,
     NetworkReturnDetailSerializer,
     NetworkReturnSerializer,
     NetworkSerializer,
+    PaginatedResultSerializer,
 )
 
-from .common import (
-    LIMIT_OFFSET_QUERY_PARAMS,
-    PAGINATED_RESULTS_SCHEMA,
-    ArangoPagination,
-    MultinetPagination,
-    WorkspaceChildMixin,
-)
-
-EDGE_DEFINITION_CREATE_SCHEMA = openapi.Schema(
-    type=openapi.TYPE_OBJECT,
-    properties={
-        'edge_table': openapi.Schema(type=openapi.TYPE_STRING),
-        'node_tables': openapi.Schema(
-            type=openapi.TYPE_ARRAY, items=openapi.Schema(type=openapi.TYPE_STRING)
-        ),
-    },
-)
+from .common import ArangoPagination, MultinetPagination, WorkspaceChildMixin
 
 
 class NetworkCreationErrorSerializer(serializers.Serializer):
@@ -136,8 +121,8 @@ class NetworkViewSet(WorkspaceChildMixin, DetailSerializerMixin, ReadOnlyModelVi
         return Response(None, status=status.HTTP_204_NO_CONTENT)
 
     @swagger_auto_schema(
-        manual_parameters=LIMIT_OFFSET_QUERY_PARAMS,
-        responses={200: PAGINATED_RESULTS_SCHEMA},
+        query_serializer=LimitOffsetSerializer(),
+        responses={200: PaginatedResultSerializer()},
     )
     @action(detail=True, url_path='nodes')
     @require_workspace_permission(WorkspaceRoleChoice.READER)
@@ -154,8 +139,8 @@ class NetworkViewSet(WorkspaceChildMixin, DetailSerializerMixin, ReadOnlyModelVi
         return pagination.get_paginated_response(paginated_query)
 
     @swagger_auto_schema(
-        manual_parameters=LIMIT_OFFSET_QUERY_PARAMS,
-        responses={200: PAGINATED_RESULTS_SCHEMA},
+        query_serializer=LimitOffsetSerializer(),
+        responses={200: PaginatedResultSerializer()},
     )
     @action(detail=True, url_path='edges')
     @require_workspace_permission(WorkspaceRoleChoice.READER)

--- a/multinet/api/views/serializers.py
+++ b/multinet/api/views/serializers.py
@@ -88,6 +88,22 @@ class SingleUserWorkspacePermissionSerializer(serializers.Serializer):
     permission_label = serializers.CharField(allow_null=True)
 
 
+class LimitOffsetSerializer(serializers.Serializer):
+    limit = serializers.IntegerField(required=False)
+    offset = serializers.IntegerField(required=False)
+
+
+class PaginatedResultSerializer(serializers.Serializer):
+    count = serializers.IntegerField()
+    previous = serializers.URLField(allow_null=True)
+    next = serializers.URLField(allow_null=True)
+    results = serializers.ListField(child=serializers.JSONField())
+
+
+class TableRowRetrieveSerializer(LimitOffsetSerializer):
+    filter = serializers.JSONField(required=False)
+
+
 # The required fields for table creation
 class TableCreateSerializer(serializers.ModelSerializer):
     class Meta:

--- a/multinet/api/views/table.py
+++ b/multinet/api/views/table.py
@@ -3,7 +3,6 @@ import json
 
 from django.shortcuts import get_object_or_404
 from django_filters import rest_framework as filters
-from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import serializers, status
 from rest_framework.decorators import action
@@ -15,19 +14,14 @@ from multinet.api.auth.decorators import require_workspace_permission
 from multinet.api.models import Table, Workspace, WorkspaceRoleChoice
 from multinet.api.utils.arango import ArangoQuery
 from multinet.api.views.serializers import (
+    PaginatedResultSerializer,
     TableCreateSerializer,
     TableReturnSerializer,
+    TableRowRetrieveSerializer,
     TableSerializer,
 )
 
-from .common import (
-    ARRAY_OF_OBJECTS_SCHEMA,
-    LIMIT_OFFSET_QUERY_PARAMS,
-    PAGINATED_RESULTS_SCHEMA,
-    ArangoPagination,
-    MultinetPagination,
-    WorkspaceChildMixin,
-)
+from .common import ArangoPagination, MultinetPagination, WorkspaceChildMixin
 
 
 class RowInsertResponseSerializer(serializers.Serializer):
@@ -90,11 +84,8 @@ class TableViewSet(WorkspaceChildMixin, ReadOnlyModelViewSet):
         return Response(None, status=status.HTTP_204_NO_CONTENT)
 
     @swagger_auto_schema(
-        manual_parameters=[
-            openapi.Parameter('filter', 'query', type='object'),
-            *LIMIT_OFFSET_QUERY_PARAMS,
-        ],
-        responses={200: PAGINATED_RESULTS_SCHEMA},
+        query_serializer=TableRowRetrieveSerializer(),
+        responses={200: PaginatedResultSerializer()},
     )
     @action(detail=True, url_path='rows')
     @require_workspace_permission(WorkspaceRoleChoice.READER)
@@ -118,7 +109,7 @@ class TableViewSet(WorkspaceChildMixin, ReadOnlyModelViewSet):
         return pagination.get_paginated_response(paginated_query)
 
     @swagger_auto_schema(
-        request_body=ARRAY_OF_OBJECTS_SCHEMA,
+        request_body=serializers.ListSerializer(child=serializers.JSONField()),
         responses={200: RowInsertResponseSerializer()},
     )
     @get_rows.mapping.put
@@ -134,7 +125,7 @@ class TableViewSet(WorkspaceChildMixin, ReadOnlyModelViewSet):
         return Response(serializer.data, status=status.HTTP_200_OK)
 
     @swagger_auto_schema(
-        request_body=ARRAY_OF_OBJECTS_SCHEMA,
+        request_body=serializers.ListSerializer(child=serializers.JSONField()),
         responses={200: RowDeleteResponseSerializer()},
     )
     @get_rows.mapping.delete


### PR DESCRIPTION
It turns out with get requests, you can use the `query_serializer` parameter of `swagger_auto_schema`. This removes the need for us to use `manual_parameters`, and allows us to handle get request parameters in a similar way to that of put/post requests.