### PR TITLE
Create endpoint to retrieve a network's tables

### DIFF
--- a/multinet/api/tests/conftest.py
+++ b/multinet/api/tests/conftest.py
@@ -1,4 +1,5 @@
 import itertools
+from typing import Optional
 
 from django.contrib.auth.models import User
 from faker import Faker
@@ -66,8 +67,10 @@ def populated_table(workspace: Workspace, edge: bool) -> Table:
         return table
 
 
-def populated_network(workspace: Workspace) -> Network:
-    populated_edge_table = populated_table(workspace, True)
+def populated_network(workspace: Workspace, edge_table: Optional[Table] = None) -> Network:
+    populated_edge_table = (
+        edge_table if edge_table is not None else populated_table(workspace, True)
+    )
     node_tables = list(populated_edge_table.find_referenced_node_tables().keys())
     network_name = Faker().pystr()
     return Network.create_with_edge_definition(

--- a/multinet/api/tests/test_network.py
+++ b/multinet/api/tests/test_network.py
@@ -403,7 +403,7 @@ def test_network_rest_retrieve_tables_all(
     edge_table = populated_table(workspace, edge=True)
     network = populated_network(workspace, edge_table=edge_table)
     node_tables = list(edge_table.find_referenced_node_tables().keys())
-    table_names = node_tables + [edge_table.name]
+    table_names = {*node_tables, edge_table.name}
 
     response = authenticated_api_client.get(
         f'/api/workspaces/{workspace.name}/networks/{network.name}/tables/'
@@ -411,9 +411,7 @@ def test_network_rest_retrieve_tables_all(
 
     if success:
         assert response.status_code == 200
-        assert len(response.data) == len(table_names)
-        for table in response.data:
-            assert table['name'] in table_names
+        assert table_names == {table['name'] for table in response.data}
     else:
         assert response.status_code == 404
 

--- a/multinet/api/views/network.py
+++ b/multinet/api/views/network.py
@@ -160,7 +160,7 @@ class NetworkViewSet(WorkspaceChildMixin, DetailSerializerMixin, ReadOnlyModelVi
         manual_parameters=[
             openapi.Parameter('type', 'query', type='string', enum=['node', 'edge'], required=False)
         ],
-        responses={200: TableReturnSerializer(many=True)},
+        responses={200: TableSerializer(many=True)},
     )
     @action(detail=True, url_path='tables')
     @require_workspace_permission(WorkspaceRoleChoice.READER)
@@ -177,6 +177,6 @@ class NetworkViewSet(WorkspaceChildMixin, DetailSerializerMixin, ReadOnlyModelVi
             table_names = network.node_tables() + network.edge_tables()
 
         network_tables = Table.objects.filter(name__in=table_names)
-        serializer = TableReturnSerializer(network_tables, many=True)
+        serializer = TableSerializer(network_tables, many=True)
 
         return Response(serializer.data, status=status.HTTP_200_OK)

--- a/multinet/api/views/network.py
+++ b/multinet/api/views/network.py
@@ -18,7 +18,7 @@ from multinet.api.views.serializers import (
     NetworkReturnDetailSerializer,
     NetworkReturnSerializer,
     NetworkSerializer,
-    NetworkTableTypeSerializer,
+    NetworkTablesSerializer,
     PaginatedResultSerializer,
     TableReturnSerializer,
 )
@@ -159,7 +159,7 @@ class NetworkViewSet(WorkspaceChildMixin, DetailSerializerMixin, ReadOnlyModelVi
         return pagination.get_paginated_response(paginated_query)
 
     @swagger_auto_schema(
-        query_serializer=NetworkTableTypeSerializer(),
+        query_serializer=NetworkTablesSerializer(),
         responses={200: TableReturnSerializer(many=True)},
     )
     @action(detail=True, url_path='tables')
@@ -168,7 +168,7 @@ class NetworkViewSet(WorkspaceChildMixin, DetailSerializerMixin, ReadOnlyModelVi
         workspace: Workspace = get_object_or_404(Workspace, name=parent_lookup_workspace__name)
         network: Network = get_object_or_404(Network, workspace=workspace, name=name)
 
-        serializer = NetworkTableTypeSerializer(data=request.query_params)
+        serializer = NetworkTablesSerializer(data=request.query_params)
         serializer.is_valid(raise_exception=True)
         table_type = serializer.validated_data.get('type', None)
         if table_type == 'node':

--- a/multinet/api/views/network.py
+++ b/multinet/api/views/network.py
@@ -19,6 +19,7 @@ from multinet.api.views.serializers import (
     NetworkReturnSerializer,
     NetworkSerializer,
     PaginatedResultSerializer,
+    TableReturnSerializer,
 )
 
 from .common import ArangoPagination, MultinetPagination, WorkspaceChildMixin
@@ -160,7 +161,7 @@ class NetworkViewSet(WorkspaceChildMixin, DetailSerializerMixin, ReadOnlyModelVi
         manual_parameters=[
             openapi.Parameter('type', 'query', type='string', enum=['node', 'edge'], required=False)
         ],
-        responses={200: TableSerializer(many=True)},
+        responses={200: TableReturnSerializer(many=True)},
     )
     @action(detail=True, url_path='tables')
     @require_workspace_permission(WorkspaceRoleChoice.READER)
@@ -177,6 +178,6 @@ class NetworkViewSet(WorkspaceChildMixin, DetailSerializerMixin, ReadOnlyModelVi
             table_names = network.node_tables() + network.edge_tables()
 
         network_tables = Table.objects.filter(name__in=table_names)
-        serializer = TableSerializer(network_tables, many=True)
+        serializer = TableReturnSerializer(network_tables, many=True)
 
         return Response(serializer.data, status=status.HTTP_200_OK)

--- a/multinet/api/views/network.py
+++ b/multinet/api/views/network.py
@@ -155,3 +155,28 @@ class NetworkViewSet(WorkspaceChildMixin, DetailSerializerMixin, ReadOnlyModelVi
         paginated_query = pagination.paginate_queryset(query, request)
 
         return pagination.get_paginated_response(paginated_query)
+
+    @swagger_auto_schema(
+        manual_parameters=[
+            openapi.Parameter('type', 'query', type='string', enum=['node', 'edge'], required=False)
+        ],
+        responses={200: TableReturnSerializer(many=True)},
+    )
+    @action(detail=True, url_path='tables')
+    @require_workspace_permission(WorkspaceRoleChoice.READER)
+    def tables(self, request, parent_lookup_workspace__name: str, name: str):
+        workspace: Workspace = get_object_or_404(Workspace, name=parent_lookup_workspace__name)
+        network: Network = get_object_or_404(Network, workspace=workspace, name=name)
+
+        table_type = request.query_params.get('type')
+        if table_type == 'node':
+            table_names = network.node_tables()
+        elif table_type == 'edge':
+            table_names = network.edge_tables()
+        else:
+            table_names = network.node_tables() + network.edge_tables()
+
+        network_tables = Table.objects.filter(name__in=table_names)
+        serializer = TableReturnSerializer(network_tables, many=True)
+
+        return Response(serializer.data, status=status.HTTP_200_OK)

--- a/multinet/api/views/network.py
+++ b/multinet/api/views/network.py
@@ -18,6 +18,7 @@ from multinet.api.views.serializers import (
     NetworkReturnDetailSerializer,
     NetworkReturnSerializer,
     NetworkSerializer,
+    NetworkTableTypeSerializer,
     PaginatedResultSerializer,
     TableReturnSerializer,
 )
@@ -158,9 +159,7 @@ class NetworkViewSet(WorkspaceChildMixin, DetailSerializerMixin, ReadOnlyModelVi
         return pagination.get_paginated_response(paginated_query)
 
     @swagger_auto_schema(
-        manual_parameters=[
-            openapi.Parameter('type', 'query', type='string', enum=['node', 'edge'], required=False)
-        ],
+        query_serializer=NetworkTableTypeSerializer(),
         responses={200: TableReturnSerializer(many=True)},
     )
     @action(detail=True, url_path='tables')
@@ -169,7 +168,9 @@ class NetworkViewSet(WorkspaceChildMixin, DetailSerializerMixin, ReadOnlyModelVi
         workspace: Workspace = get_object_or_404(Workspace, name=parent_lookup_workspace__name)
         network: Network = get_object_or_404(Network, workspace=workspace, name=name)
 
-        table_type = request.query_params.get('type')
+        serializer = NetworkTableTypeSerializer(data=request.query_params)
+        serializer.is_valid(raise_exception=True)
+        table_type = serializer.validated_data.get('type', None)
         if table_type == 'node':
             table_names = network.node_tables()
         elif table_type == 'edge':

--- a/multinet/api/views/serializers.py
+++ b/multinet/api/views/serializers.py
@@ -174,7 +174,7 @@ class NetworkReturnDetailSerializer(serializers.ModelSerializer):
 
 
 class NetworkTablesSerializer(serializers.Serializer):
-    type = serializers.ChoiceField(choices=['node', 'edge'], required=False)
+    type = serializers.ChoiceField(choices=['node', 'edge', 'all'], default='all', required=False)
 
 
 class UploadCreateSerializer(serializers.Serializer):

--- a/multinet/api/views/serializers.py
+++ b/multinet/api/views/serializers.py
@@ -173,7 +173,7 @@ class NetworkReturnDetailSerializer(serializers.ModelSerializer):
     workspace = WorkspaceSerializer()
 
 
-class NetworkTableTypeSerializer(serializers.Serializer):
+class NetworkTablesSerializer(serializers.Serializer):
     type = serializers.ChoiceField(choices=['node', 'edge'], required=False)
 
 

--- a/multinet/api/views/serializers.py
+++ b/multinet/api/views/serializers.py
@@ -173,6 +173,10 @@ class NetworkReturnDetailSerializer(serializers.ModelSerializer):
     workspace = WorkspaceSerializer()
 
 
+class NetworkTableTypeSerializer(serializers.Serializer):
+    type = serializers.ChoiceField(choices=['node', 'edge'], required=False)
+
+
 class UploadCreateSerializer(serializers.Serializer):
     field_value = serializers.CharField()
 


### PR DESCRIPTION
Closes #73 

This PR creates the following endpoint:

`GET /api/workspaces/{workspace}/networks/{network}/tables/`
which can be used to retrieve information about node and edge tables that make up a particular network. It accepts an optional query parameter, `type`, which can be equal to `node` or `edge`, in which case the response will only contain tables of that type.

Omitting the query parameter will return tables of both types.

This endpoint is useful for client applications such as `multimatrix`, which uses table names to generate particular AQL queries.