### PR TITLE
Increase AQL memory limit to 1GiB from 20MB

### DIFF
--- a/multinet/api/utils/arango.py
+++ b/multinet/api/utils/arango.py
@@ -59,7 +59,7 @@ class ArangoQuery:
         query_str: Optional[str] = None,
         bind_vars: Optional[Dict[str, str]] = None,
         time_limit_secs: int = 30,
-        memory_limit_bytes: int = 20000000,  # 20MB
+        memory_limit_bytes: int = 1 * 1024 * 1024 * 1024,  # 1GiB
     ) -> None:
         self.db = db
         self.query_str = query_str


### PR DESCRIPTION
Depends on #89 

This fixes an issue I've been having on UPDB with applying filters to a query. When I would add the filters, I'd hit this memory limit.

Increasing the limit here fixes the problem. There are still issue on the main client with showing the number of nodes and the "node types". I think that we can modify the queries that run on `/nodes/?offset=0&limit=10` to reduce the memory use, since it shouldn't need to load every table to get the count.