### PR TITLE
Fix django major version to 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'celery',
-        'django',
+        'django~=3.2.11',
         'django-admin-display',
         'django-allauth',
         'django-composed-configuration[dev,prod]>=0.10.0',


### PR DESCRIPTION
### Does this PR close any open issues?
No, I have noticed this issue when rebuilding the django container locally, though.

### Give a longer description of what this PR addresses and why it's needed
This fixes the django major (and maybe minor version) to 3(.2). This stops the django containers, and presumably the heroku deployment, from using django v4.0, which our code is not compatible with. We're using some deprecated and removed functions.

We should hold off on merging any other PR until this is merged.

### Provide pictures/videos of the behavior before and after these changes (optional)
N/A

### Are there any additional TODOs before this PR is ready to go?
No