### PR TITLE
Add chunking to put_rows and delete_rows

### DIFF
--- a/multinet/api/models/table.py
+++ b/multinet/api/models/table.py
@@ -66,7 +66,6 @@ class Table(TimeStampedModel):
 
         # Limit the amount of rows inserted per request, to prevent timeouts
         for chunk in chunked(rows, DOCUMENT_CHUNK_SIZE):
-            print(len(chunk))
             res = self.get_arango_collection(readonly=False).insert_many(chunk, overwrite=True)
             errors.extend(
                 (

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         'djangorestframework',
         'drf-extensions',
         'drf-yasg',
+        'more-itertools',
         'python-arango',
         # Production-only
         'gunicorn',


### PR DESCRIPTION
Depends #89
### Does this PR close any open issues?
Closes #85

### Give a longer description of what this PR addresses and why it's needed
This chunks the upload using hints from #85. I used almost exactly the same syntax, while making sure to not use the `readonly` user. The upload runs with chunks of 5000 rows, which may be too small.

### Provide pictures/videos of the behavior before and after these changes (optional)
N/A

### Are there any additional TODOs before this PR is ready to go?
No.