### PR TITLE
Update D3 JSON uploader to handle missing keys

### DIFF
--- a/multinet/api/tasks/upload/d3_json.py
+++ b/multinet/api/tasks/upload/d3_json.py
@@ -55,18 +55,16 @@ def process_d3_json(
         d3_dict = json.loads(blob_file.read().decode('utf-8'))
 
     # Change column names from the d3 format to the arango format
-    d3_dict['nodes'] = list(
-        filter(
-            lambda x: x is not None,
-            (d3_node_to_arango_doc(node) for node in d3_dict['nodes']),
-        )
-    )
-    d3_dict['links'] = list(
-        filter(
-            lambda x: x is not None,
-            (d3_link_to_arango_doc(link, node_table_name) for link in d3_dict['links']),
-        )
-    )
+    d3_dict['nodes'] = [
+        node
+        for node in (d3_node_to_arango_doc(node) for node in d3_dict['nodes'])
+        if node is not None
+    ]
+    d3_dict['links'] = [
+        link
+        for link in (d3_link_to_arango_doc(link, node_table_name) for link in d3_dict['links'])
+        if link is not None
+    ]
 
     # Create ancillary tables
     node_table: Table = Table.objects.create(


### PR DESCRIPTION
This PR addresses https://github.com/multinet-app/multinet-client/issues/216, by changing the way json files are processed. It used to be the case that `nodes[*].id` and `links[*].<source|target>` were assumed to be present, failing the upload if they were missing. This has been updated, so that if these keys are missing for any node/link, that specific node/link is skipped, and not ingested into the network.