### PR TITLE
Add post-processed graph analytics from networkX

### DIFF
--- a/dev/django.Dockerfile
+++ b/dev/django.Dockerfile
@@ -1,10 +1,27 @@
-FROM python:3.8-slim
+FROM ubuntu:20.04
+
+
 # Install system librarires for Python packages:
 # * psycopg2
 RUN apt-get update && \
     apt-get install --no-install-recommends --yes \
         libpq-dev gcc libc6-dev && \
     rm -rf /var/lib/apt/lists/*
+
+# install graph-tool for postprocessing
+RUN apt-get update
+RUN apt-get install -qy apt-utils
+RUN apt-get -qy install software-properties-common
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-key 612DEFB798507F25
+RUN add-apt-repository 'deb [ arch=amd64 ] https://downloads.skewed.de/apt focal main'
+
+RUN apt-get update
+RUN apt-get install -qy python3-graph-tool
+
+RUN apt-get install -qy python3-pip
+
+# make python3 the default
+RUN apt-get install -qy python-is-python3
 
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1

--- a/multinet/api/views/network.py
+++ b/multinet/api/views/network.py
@@ -161,10 +161,10 @@ def BuildNodeAndEdgeAttributeStructure_gtool(g,node_list,edge_list):
             edge_attrs[column]['value'] = edge_id_prop
             g.edge_properties[column] = edge_id_prop
             
-    # make a dict of all nodes indexed by 'id' to help lookup faster when we are adding edges
+    # make a dict of all nodes indexed by '_id' to help lookup faster when we are adding edges
     node_dict = {}
     for node in node_list:
-        node_dict[node['id']] = node
+        node_dict[node['_id']] = node
             
     # now fill in the edge values. We have to look up the proper edge by its start and end nodes
     for edge in edge_list:
@@ -172,7 +172,7 @@ def BuildNodeAndEdgeAttributeStructure_gtool(g,node_list,edge_list):
         destNode   = node_dict[edge['_to']]['gt_object']
         thisEdge = g.edge(sourceNode,destNode)
         for attrib in edge:
-            if attrib not in ['subject','object','_from','_to']:
+            if attrib not in ['_from','_to']:
                 #print('edge attrib:',attrib)
                 edge_attrs[attrib]['value'][thisEdge] = edge[attrib]
         

--- a/multinet/api/views/network.py
+++ b/multinet/api/views/network.py
@@ -269,26 +269,50 @@ class NetworkViewSet(WorkspaceChildMixin, DetailSerializerMixin, ReadOnlyModelVi
         # traverse through arango cursors to get data into lists
         timestamps = []
         timestamps.append(('before cursor read',arrow.now()))
-        edge_list = []
-        node_list = []
-        edges = network.edges()
-        nodes = network.nodes()
 
         # iterate through Arango cursors to extract the node and edge data
+        # arango queries are buffered by default pagination of 
+        # 1000 entries, so loop through all the batches
+        edge_list = []
+        node_list = []
+
+        edges = network.edges()
+        # loop until there are no more batches waiting
+        if edges.has_more():
+            while edges.has_more():
+                while not edges.empty():
+                    edge = edges.next()
+                    edge_list.append(edge)
+                # advance to the last partial batch
+                edges.fetch()
+        # get the last partial batch
         while not edges.empty():
             edge = edges.next()
             edge_list.append(edge)
-            #print(edge)
+
+        nodes = network.nodes()
+        # loop until there are no more batches waiting
+        if nodes.has_more():
+            while nodes.has_more():
+                while not nodes.empty():
+                    node = nodes.next()
+                    node_list.append(node)
+                nodes.fetch()
+        # get the last partial batch
         while not nodes.empty():
             node = nodes.next()
             node_list.append(node)
-            #print(node)
+
+
 
         timestamps.append(('after cursor read',arrow.now()))
-        print('found',len(node_list),'nodes and ',len(edge_list),'edges')   
+        edgecount = network.edge_count
+
+        #print('network has:',edgecount,'edges')
+        #print('found',len(node_list),'nodes and ',len(edge_list),'edges')   
         # print a sample to observe we are traversing correctly
-        print('node[2]:',node_list[2])   
-        print('edge[2]:',edge_list[2])   
+        #print('node[2]:',node_list[2])   
+        #print('edge[2]:',edge_list[2])   
 
         timestamps.append(('before graph creation',arrow.now()))
         nxNetwork = buildGraph_netX(node_list,edge_list)
@@ -335,9 +359,9 @@ class NetworkViewSet(WorkspaceChildMixin, DetailSerializerMixin, ReadOnlyModelVi
                 entry['result'] = nxNetwork.out_degree(index+1)
             node_stat_list.append(entry)
 
-        for stamp in range(len(timestamps)-1):
-            diff = timestamps[stamp+1][1]-timestamps[stamp][1]
-            print(timestamps[stamp+1][0],diff)
+        #for stamp in range(len(timestamps)-1):
+        #    diff = timestamps[stamp+1][1]-timestamps[stamp][1]
+        #    print(timestamps[stamp+1][0],diff)
 
         if algorithm == 'all':
             serializer = NodeStatsAllFieldsSerializer(node_stat_list, many=True)
@@ -370,14 +394,36 @@ class NetworkViewSet(WorkspaceChildMixin, DetailSerializerMixin, ReadOnlyModelVi
         # traverse through arango cursors to get data into lists
         timestamps = []
         timestamps.append(('before cursor read',arrow.now()))
+     
+        # iterate through Arango cursors to extract the node and edge data
+        # arango queries are buffered by default pagination of 
+        # 1000 entries, so loop through all the batches
         edge_list = []
         node_list = []
+
         edges = network.edges()
+        # loop until there are no more batches waiting
+        if edges.has_more():
+            while edges.has_more():
+                while not edges.empty():
+                    edge = edges.next()
+                    edge_list.append(edge)
+                # advance to the last partial batch
+                edges.fetch()
+        # get the last partial batch
         while not edges.empty():
             edge = edges.next()
             edge_list.append(edge)
-            #print(edge)
+
         nodes = network.nodes()
+        # loop until there are no more batches waiting
+        if nodes.has_more():
+            while nodes.has_more():
+                while not nodes.empty():
+                    node = nodes.next()
+                    node_list.append(node)
+                nodes.fetch()
+        # get the last partial batch
         while not nodes.empty():
             node = nodes.next()
             node_list.append(node)
@@ -425,19 +471,39 @@ class NetworkViewSet(WorkspaceChildMixin, DetailSerializerMixin, ReadOnlyModelVi
         # traverse through arango cursors to get data into lists
         timestamps = []
         timestamps.append(('before cursor read',arrow.now()))
+
+        # iterate through Arango cursors to extract the node and edge data
+        # arango queries are buffered by default pagination of 
+        # 1000 entries, so loop through all the batches
         edge_list = []
         node_list = []
+
         edges = network.edges()
-        # Question: should this be a test of cursor.has_more() instead? what is the batch size?
-        # iterate through Arango cursors to extract the node and edge data
+        # loop until there are no more batches waiting
+        if edges.has_more():
+            while edges.has_more():
+                while not edges.empty():
+                    edge = edges.next()
+                    edge_list.append(edge)
+                # advance to the last partial batch
+                edges.fetch()
+        # get the last partial batch
         while not edges.empty():
             edge = edges.next()
             edge_list.append(edge)
-            #print(edge)
+
         nodes = network.nodes()
+        # loop until there are no more batches waiting
+        if nodes.has_more():
+            while nodes.has_more():
+                while not nodes.empty():
+                    node = nodes.next()
+                    node_list.append(node)
+                nodes.fetch()
+        # get the last partial batch
         while not nodes.empty():
             node = nodes.next()
-            node_list.append(node)
+            node_list.append(node)     
 
 
         timestamps.append(('before graph creation',arrow.now()))

--- a/multinet/api/views/network.py
+++ b/multinet/api/views/network.py
@@ -32,13 +32,15 @@ from multinet.api.views.serializers import (
 from .common import ArangoPagination, MultinetPagination, WorkspaceChildMixin
 
 # added for graph library exploration
-import networkx as nx
+from graph_tool.all import *
+from graph_tool.centrality import pagerank
+from graph_tool.centrality import betweenness
+from graph_tool.centrality import katz
 import arrow
 from django.http import JsonResponse
 import json
+import pandas as pd
 
-
-## -------------------- CRL added supporting routines for graph manipulation using networkX
 
 # develop accessor function to return node index from _key. Be tolerant of
 # table names preceding the unique node name
@@ -80,33 +82,168 @@ def buildGraph_netX(node_list,edge_list):
     return g
 
 # return a subset of a graph by filtering by node in or out degree
-def subsetGraph_netX(g,algorithm,lowerBound,upperBound):
-    def in_node_filter(index):
-        return (g.in_degree(index)>=lowerBound and g.in_degree(index)<=upperBound)
-    def out_node_filter(index):
-        return (g.out_degree(index)>=lowerBound and g.out_degree(index)<=upperBound)
-    def degree_node_filter(index):
-        return (in_node_filter(index) or out_node_filter(index))
+def subsetGraph_gtool(g,algorithm,lowerBound,upperBound):
     if algorithm == 'in_degree':
-        view = nx.subgraph_view(g, filter_node=in_node_filter)
+        view = GraphView(g, vfilt=lambda v: (v.in_degree() >= lowerBound and v.in_degree() <= upperBound))
     elif algorithm == 'out_degree':
-        view = nx.subgraph_view(g, filter_node=out_node_filter)
+        view = GraphView(g, vfilt=lambda v: (v.out_degree() >= lowerBound and v.out_degree() <= upperBound))
+        # vcount = 0
+        # for v in view.vertices():
+        #     if (vcount<5):
+        #         print('vert info:',v)
+        #     vcount += 1
+
     else:
-        view = nx.subgraph_view(g, filter_node=degree_node_filter)
+        # or of two conditions gives 'degree' (either in or out conditions match)
+        view = GraphView(g, vfilt=lambda v: ((v.out_degree() >= lowerBound and v.out_degree() <= upperBound) or 
+                                             (v.in_degree() >= lowerBound and v.in_degree() <= upperBound))
+                                             )
     return view
 
 
-def calculateNodeCentrality_netX(g):
-    returnValues = nx.degree_centrality(g)
-    return returnValues
 
-def calculateBetweenness_netX(g):
-    returnValues = nx.betweenness_centrality(g)
-    return returnValues
+# given a list of nodes and edges with arbitrary attributes, create graph_tool attribute structures
+def BuildNodeAndEdgeAttributeStructure_gtool(g,node_list,edge_list):
+    # get dataframe version so we can use pandas type analysis API
+    node_df = pd.DataFrame(node_list)
+    edge_df = pd.DataFrame(edge_list)
+    # find all the attributes on the nodes and edges
+    node_attrs = {}
+    edge_attrs = {}
+    infer_type = lambda x: pd.api.types.infer_dtype(x, skipna=True)
     
+    # find the node properties
+    for column in node_df.columns:
+        if column not in ['gt_object','used_by_edge','index']:
+            #print(column)
+            # return node attribute types as a pandas series
+            node_types = node_df.apply(infer_type, axis=0)
+            # create a dictionary that includes type and value keys. The
+            # value will be an instance of a graph-tool vertex_properties object
+            node_attrs[column] = {}
+            node_attrs[column]['type'] = node_types[column]       
+            if node_types[column] == 'string':
+                vert_id_prop = g.new_vertex_property("string")
+            elif node_types[column] == 'integer':
+                vert_id_prop = g.new_vertex_property("int")
+            else:
+                vert_id_prop = g.new_vertex_property("float")           
+            node_attrs[column]['value'] = vert_id_prop
+            g.vertex_properties[column] = vert_id_prop
+            #print('id of inside graph:',id(g))
+    
+            
+    # now fill in all the node property values
+    for node in node_list:
+        for attrib in node.keys():
+            if attrib not in ['gt_object','used_by_edge','index']:
+                #print(node['id'],attrib)
+                # assign the attribute value to the proper place in the vertex_properties object
+                # the node['gt_object'] is the index into the property object, which is shared across all nodes
+                node_attrs[attrib]['value'][node['gt_object']] = node[attrib]
 
-# --------------- end of graph support routines
+    # find the edge properties
+    for column in edge_df.columns:
+        if column not in []:
+            #print(column)
+            # return node attribute types as a pandas series
+            edge_types = edge_df.apply(infer_type, axis=0)
+            # create a dictionary that includes type and value keys. The
+            # value will be an instance of a graph-tool vertex_properties object
+            edge_attrs[column] = {}
+            edge_attrs[column]['type'] = edge_types[column]       
+            if edge_types[column] == 'string':
+                edge_id_prop = g.new_edge_property("string")
+            elif edge_types[column] == 'integer':
+                edge_id_prop = g.new_edge_property("int")
+            else:
+                edge_id_prop = g.new_edge_property("float")           
+            edge_attrs[column]['value'] = edge_id_prop
+            g.edge_properties[column] = edge_id_prop
+            
+    # make a dict of all nodes indexed by 'id' to help lookup faster when we are adding edges
+    node_dict = {}
+    for node in node_list:
+        node_dict[node['id']] = node
+            
+    # now fill in the edge values. We have to look up the proper edge by its start and end nodes
+    for edge in edge_list:
+        sourceNode = node_dict[edge['subject']]['gt_object']
+        destNode   = node_dict[edge['object']]['gt_object']
+        thisEdge = g.edge(sourceNode,destNode)
+        for attrib in edge:
+            if attrib not in ['subject','object','_from','_to']:
+                #print('edge attrib:',attrib)
+                edge_attrs[attrib]['value'][thisEdge] = edge[attrib]
+        
+    # return attribute structures
+    return (node_attrs,edge_attrs)
 
+# build a graph-tool network based on the nodes and edges passed in dataframes. This routine supports
+# arbitrary node and edge attributes 
+def buildGraph_gtool(node_list,edge_list):   
+    #print('found ',len(edge_list), 'edges')
+    #print('found ',len(node_list), 'nodes')
+    edge_df = pd.DataFrame(edge_list)
+    node_df = pd.DataFrame(node_list)
+    #print(node_list[0])
+    g = Graph(directed=True)
+    #print('id of graph:',id(g))
+    
+    # first we put the nodes in a dictionary, indexed by their primary key, so we can retrieve the node 
+    potential_nodes = {}
+    index = 0
+    duplicate_nodes = []
+    #print('node sample',node_list[:1])
+    for node in node_list:
+        node['index'] = index
+        #node['gt_object'] = g.add_vertex()
+        if node['_id'] in potential_nodes.keys():
+            duplicate_nodes.append(node)
+        potential_nodes[node['_id']] = node
+        index += 1
+        # debug, we shouldn't have extra, but indicate if dups exist
+        if len(duplicate_nodes)>0:
+            print('found ',len(duplicate_nodes),'duplicate nodes')
+
+    # now go through the edges and see which ones connect nodes in the potential_nodes dictionary
+    edge_count = 0
+    #print('edge sample',edge_list[:1])
+    for edge in edge_list:
+        if (edge['_to'] in potential_nodes.keys()) and (edge['_from'] in potential_nodes.keys()):
+            # record a record in the node, so we remember which nodes are needed
+            potential_nodes[edge['_to']]['used_by_edge'] = 1
+            potential_nodes[edge['_from']]['used_by_edge']  = 1
+            edge_count += 1
+    #print('found ',edge_count, 'edges between known nodes')   
+    # add all the nodes that were used by edges
+    count = 0
+    used_nodes = {}
+    used_node_ids_in_order = []
+    used_node_list = []
+    for node in potential_nodes.keys():
+        #print(potential_nodes[node]['id'])
+        if 'used_by_edge' in potential_nodes[node]:
+            count += 1
+            # add the node to the graph and keep record of the record we create
+            potential_nodes[node]['gt_object'] = g.add_vertex()
+            used_node_ids_in_order.append(node)
+            #used_nodes[node] = potential_nodes[node]
+            used_node_list.append(potential_nodes[node])
+    #print('unnecessary used_nodes dictionary here?')
+    #print('used ',count,'nodes')
+    # we have added the nodes to the graph, now add the edges and retrieve the node records from the potential_nodes dictionry
+    used_edge_list = []
+    for edge in edge_list:
+        if (edge['_from'] in potential_nodes.keys()) and (edge['_to'] in potential_nodes.keys()):
+            newEdge = g.add_edge((potential_nodes[edge['_from']])['gt_object'],(potential_nodes[edge['_to']])['gt_object'])
+            used_edge_list.append(edge)
+    #print('really used ',len(used_edge_list),'edges')
+    # now that we know what node and edge records are used, lets add attributes to the graph. the used_nodes and used_edges
+    # are lists of dicts that contain all the attributes
+    node_attrs,edge_attrs = BuildNodeAndEdgeAttributeStructure_gtool(g,used_node_list,used_edge_list)
+    # return the graph-tool graph object 
+    return (g, node_attrs, edge_attrs)
 
 
 
@@ -307,28 +444,22 @@ class NetworkViewSet(WorkspaceChildMixin, DetailSerializerMixin, ReadOnlyModelVi
             node_list.append(node)
 
         timestamps.append(('after cursor read',arrow.now()))
-        edgecount = network.edge_count
-
-        #print('network has:',edgecount,'edges')
-        #print('found',len(node_list),'nodes and ',len(edge_list),'edges')   
-        # print a sample to observe we are traversing correctly
-        #print('node[2]:',node_list[2])   
-        #print('edge[2]:',edge_list[2])   
+        edgecount = network.edge_count  
 
         timestamps.append(('before graph creation',arrow.now()))
-        nxNetwork = buildGraph_netX(node_list,edge_list)
+        gtoolNetwork, node_attrs, edge_attrs  = buildGraph_gtool(node_list,edge_list)
         timestamps.append(('after graph creation',arrow.now()))
 
         if algorithm == 'node_centrality':
-            algorithmReturn = calculateNodeCentrality_netX(nxNetwork)
+            algorithmReturn = katz(gtoolNetwork)
         elif algorithm == 'betweenness':
-            algorithmReturn = calculateBetweenness_netX(nxNetwork)
+            algorithmReturn, edge_betweenness = betweenness(gtoolNetwork)
         elif algorithm == 'pagerank':
-            algorithmReturn = nx.pagerank(nxNetwork)
+            algorithmReturn = pagerank(gtoolNetwork)
         elif algorithm == 'all':
-            nodeCentrality_result = calculateNodeCentrality_netX(nxNetwork)
-            betweenness_result = calculateBetweenness_netX(nxNetwork)
-            pagerank_result = nx.pagerank(nxNetwork)
+            nodeCentrality_result = katz(gtoolNetwork)
+            betweenness_result, edge_betweenness = betweenness(gtoolNetwork)
+            pagerank_result = pagerank(gtoolNetwork)
         
         timestamps.append(('after algorithm completed',arrow.now()))
 
@@ -338,26 +469,33 @@ class NetworkViewSet(WorkspaceChildMixin, DetailSerializerMixin, ReadOnlyModelVi
             entry = {}
             # add in the node _key for reference
             entry['_key'] = node['_key']
+            entry['_id'] = node['_id']
             # fill in the result value according to what algorithm was selected
             if algorithm in ['node_centrality','betweenness']:
-                entry['result'] = algorithmReturn[index+1]
+                try:
+                    entry['result'] = algorithmReturn[index]
+                except:
+                    # there was no value for this vertex index, so return -1 flag
+                    print('returning -1 for',node['_key'])
+                    entry['result'] = -1
             elif algorithm == 'in_degree':
-                entry['result'] = nxNetwork.in_degree(index+1)
+                entry['result'] = gtoolNetwork.vertex(index).in_degree()
             elif algorithm == 'out_degree':
-                entry['result'] = nxNetwork.out_degree(index+1)
-            elif algorithm == 'node_centrality':
-                entry['result'] = algorithmReturn[index+1]
+                entry['result'] = gtoolNetwork.vertex(index).out_degree()
+            elif algorithm == 'degree':
+                entry['result'] = gtoolNetwork.vertex(index).in_degree()+gtoolNetwork.vertex(index).out_degree()
             elif algorithm == 'pagerank':
-                entry['result'] = algorithmReturn[index+1]
+                entry['result'] = algorithmReturn[index]
             elif algorithm == 'all':
-                entry['in_degree'] = nxNetwork.in_degree(index+1)
-                entry['out_degree'] = nxNetwork.out_degree(index+1)
-                entry['node_centrality'] = nodeCentrality_result[index+1]
-                entry['betweenness'] = betweenness_result[index+1]
-                entry['pagerank'] = pagerank_result[index+1]
+                entry['degree'] = gtoolNetwork.vertex(index).out_degree() + gtoolNetwork.vertex(index).in_degree()
+                entry['in_degree'] = gtoolNetwork.vertex(index).in_degree()
+                entry['out_degree'] = gtoolNetwork.vertex(index).out_degree()
+                entry['node_centrality'] = nodeCentrality_result[index]
+                entry['betweenness'] = betweenness_result[index]
+                entry['pagerank'] = pagerank_result[index]
             else:
                 # return out-degree as a default
-                entry['result'] = nxNetwork.out_degree(index+1)
+                entry['result'] = gtoolNetwork.out_degree(index)
             node_stat_list.append(entry)
 
         #for stamp in range(len(timestamps)-1):
@@ -431,25 +569,29 @@ class NetworkViewSet(WorkspaceChildMixin, DetailSerializerMixin, ReadOnlyModelVi
             node_list.append(node)
 
         timestamps.append(('before graph creation',arrow.now()))
-        nxNetwork = buildGraph_netX(node_list,edge_list)
+        gtoolNetwork, node_attrs, edge_attrs  = buildGraph_gtool(node_list,edge_list)
         timestamps.append(('after graph creation',arrow.now()))
-        smallNetwork = subsetGraph_netX(nxNetwork,algorithm,lowerBound, upperBound)
+        smallNetwork = subsetGraph_gtool(gtoolNetwork,algorithm,lowerBound, upperBound)
         timestamps.append(('after graph subset',arrow.now()))
-        #print('timestamps:')
-        #print(timestamps)
         for stamp in range(len(timestamps)-1):
             diff = timestamps[stamp+1][1]-timestamps[stamp][1]
             print(timestamps[stamp+1][0],diff)
 
-        print('reduced graph has ',nx.number_of_nodes(smallNetwork),'nodes')
-        print('reduced graph has ',nx.number_of_edges(smallNetwork),'edges')
-
         # iterate over the nodes returned and build a json structure that
         # contains all the node information
-        node_iter = list(smallNetwork.nodes)
+        vertcount = 0
         out_list = []
-        for index in node_iter:
-            out_list.append(node_list[index-1])
+        for v in smallNetwork.vertices():
+            # vertex object attributes are stored in a graph_tool node_attr structure for the
+            # the entire graph.  traverse all attributes, then get the value for this attribute
+            # from the structure.  Build out records a node at a time.  This should work for an arbitrary
+            # number and type of attributes. 
+            out_record = {}
+            for attribute in node_attrs:
+                out_record[attribute] = node_attrs[attribute]['value'][int(v)]
+            out_list.append(out_record)
+            vertcount += 1
+        print('resulting subgraph had',vertcount,'nodes')
         return JsonResponse(out_list,safe=False)
 
 
@@ -508,25 +650,18 @@ class NetworkViewSet(WorkspaceChildMixin, DetailSerializerMixin, ReadOnlyModelVi
             node = nodes.next()
             node_list.append(node)     
 
-
         timestamps.append(('before graph creation',arrow.now()))
-        nxNetwork = buildGraph_netX(node_list,edge_list)
+        gtoolNetwork, node_attrs,edge_attrs = buildGraph_gtool(node_list,edge_list)
         timestamps.append(('after graph creation',arrow.now()))
-        smallNetwork = subsetGraph_netX(nxNetwork,algorithm,lowerBound,upperBound)
+        smallNetwork = subsetGraph_gtool(gtoolNetwork,algorithm,lowerBound,upperBound)
         timestamps.append(('after graph subset',arrow.now()))
-      
 
-        print('reduced graph has ',nx.number_of_nodes(smallNetwork),'nodes')
-        print('reduced graph has ',nx.number_of_edges(smallNetwork),'edges')
-
-        # now we need to build a lookup table that maps each edge from its
-        # node indices, e.g. (2,4), to its full data so we can output the edges
-        # of a reduced graph
-        edgeIndexToData = {}
-        for edge in edge_list:
-            fromIndex = nodeKeyToNumber(nxNetwork,edge['_from'])
-            toIndex = nodeKeyToNumber(nxNetwork,edge['_to'])
-            edgeIndexToData[(fromIndex,toIndex)] = edge
+        vertcount = edgecount = 0
+        for vert in smallNetwork.vertices():
+            vertcount += 1
+        for edge in smallNetwork.edges():
+            edgecount += 1
+        print('reduced network has',vertcount,' nodes and',edgecount,'edges')
 
         # print('timestamps:')
         # for stamp in range(len(timestamps)-1):
@@ -534,14 +669,17 @@ class NetworkViewSet(WorkspaceChildMixin, DetailSerializerMixin, ReadOnlyModelVi
         #     print(timestamps[stamp+1][0],diff)
 
         # iterate over the edges returned and build a json structure that
-        # contains all the edge information.  This is complicated because networkX returns
-        # only a index tuple, do we use the index we built during the inital traversal to 
-        # recover the edge metadata
-        edge_iter = list(smallNetwork.edges)
+        # contains all the edge information.  Iterating over the edge_attrs returns
+        # all attributes except the _from and _to nodes, so we pick them out of the node_attrs
         out_list = []
-        for edgeTuple in edge_iter:
-            edgeMetadata = edgeIndexToData[edgeTuple]
-            out_list.append(edgeMetadata)
+        for edge in smallNetwork.edges():
+            out_record = {}
+            for attribute in edge_attrs:
+                out_record[attribute] = edge_attrs[attribute]['value'][edge]
+            out_record['_from'] = node_attrs['_key']['value'][edge.source()]
+            out_record['_to'] = node_attrs['_key']['value'][edge.target()]
+            out_list.append(out_record)
+        
         return JsonResponse(out_list,safe=False)
 
 

--- a/multinet/api/views/network.py
+++ b/multinet/api/views/network.py
@@ -168,8 +168,8 @@ def BuildNodeAndEdgeAttributeStructure_gtool(g,node_list,edge_list):
             
     # now fill in the edge values. We have to look up the proper edge by its start and end nodes
     for edge in edge_list:
-        sourceNode = node_dict[edge['subject']]['gt_object']
-        destNode   = node_dict[edge['object']]['gt_object']
+        sourceNode = node_dict[edge['_from']]['gt_object']
+        destNode   = node_dict[edge['_to']]['gt_object']
         thisEdge = g.edge(sourceNode,destNode)
         for attrib in edge:
             if attrib not in ['subject','object','_from','_to']:

--- a/multinet/api/views/network.py
+++ b/multinet/api/views/network.py
@@ -189,11 +189,19 @@ def BuildNodeAndEdgeAttributeStructure_gtool(g,node_list,edge_list):
     for edge in edge_list:
         sourceNode = node_dict[edge['_from']]['gt_object']
         destNode   = node_dict[edge['_to']]['gt_object']
-        thisEdge = g.edge(sourceNode,destNode)
-        for attrib in edge:
-            if attrib not in ['_from','_to']:
-                #print('edge attrib:',attrib)
-                edge_attrs[attrib]['value'][thisEdge] = edge[attrib]
+        try: 
+            thisEdge = g.edge(sourceNode,destNode)
+            for attrib in edge:
+                if attrib not in ['_from','_to']:
+                    ## catch bad attribute values and assign an error code to avoid run-time failures
+                    try:
+                        edge_attrs[attrib]['value'][thisEdge] = edge[attrib]
+                    except:
+                        print('edge',thisEdge,'has bad attribute',attrib,'value:',edge[attrib])
+                        edge_attrs[attrib]['value'][thisEdge] = ERROR_ATTRIBUTE_VALUE
+        except:
+            # skip this edge
+            print('could not find matching edge for (',sourceNode,destNode,')')
         
     # return attribute structures
     return (node_attrs,edge_attrs)

--- a/multinet/api/views/serializers.py
+++ b/multinet/api/views/serializers.py
@@ -247,3 +247,25 @@ class CSVUploadCreateSerializer(UploadCreateSerializer):
 
 class D3JSONUploadCreateSerializer(UploadCreateSerializer):
     network_name = serializers.CharField()
+
+# define the output of the node_stats endpoint.  It is either a single value or a fixed set of values
+class NodeStatsSerializer(serializers.Serializer):
+    _key = serializers.CharField()
+    result = serializers.FloatField()
+
+class NodeStatsAllFieldsSerializer(serializers.Serializer):
+    _key = serializers.CharField()
+    in_degree = serializers.FloatField()
+    out_degree = serializers.FloatField()
+    node_centrality = serializers.FloatField()
+    betweenness = serializers.FloatField()
+    pagerank = serializers.FloatField()
+
+# define the input options for the node stats queries.  
+class NodeStatsQuerySerializer(serializers.Serializer):
+    algorithm = serializers.ChoiceField(choices=['in_degree', 'out_degree','node_centrality', 'betweenness','pagerank','all'], default='all', required=False)
+
+# define the input options for the filtered node and filtered edge calls.
+class NodeAndEdgeFilteredQuerySerializer(serializers.Serializer):
+    algorithm = serializers.ChoiceField(choices=['in_degree', 'out_degree'], default='out_degree', required=False)
+    threshold = serializers.FloatField()

--- a/multinet/api/views/serializers.py
+++ b/multinet/api/views/serializers.py
@@ -267,5 +267,6 @@ class NodeStatsQuerySerializer(serializers.Serializer):
 
 # define the input options for the filtered node and filtered edge calls.
 class NodeAndEdgeFilteredQuerySerializer(serializers.Serializer):
-    algorithm = serializers.ChoiceField(choices=['in_degree', 'out_degree'], default='out_degree', required=False)
-    threshold = serializers.FloatField()
+    algorithm = serializers.ChoiceField(choices=['degree','in_degree', 'out_degree'], default='degree', required=False)
+    lowerBound = serializers.FloatField()
+    upperBound = serializers.FloatField()

--- a/multinet/api/views/serializers.py
+++ b/multinet/api/views/serializers.py
@@ -251,10 +251,13 @@ class D3JSONUploadCreateSerializer(UploadCreateSerializer):
 # define the output of the node_stats endpoint.  It is either a single value or a fixed set of values
 class NodeStatsSerializer(serializers.Serializer):
     _key = serializers.CharField()
+    _id = serializers.CharField()
     result = serializers.FloatField()
 
 class NodeStatsAllFieldsSerializer(serializers.Serializer):
     _key = serializers.CharField()
+    _id = serializers.CharField()
+    degree = serializers.FloatField()
     in_degree = serializers.FloatField()
     out_degree = serializers.FloatField()
     node_centrality = serializers.FloatField()
@@ -263,7 +266,7 @@ class NodeStatsAllFieldsSerializer(serializers.Serializer):
 
 # define the input options for the node stats queries.  
 class NodeStatsQuerySerializer(serializers.Serializer):
-    algorithm = serializers.ChoiceField(choices=['in_degree', 'out_degree','node_centrality', 'betweenness','pagerank','all'], default='all', required=False)
+    algorithm = serializers.ChoiceField(choices=['degree','in_degree', 'out_degree','node_centrality', 'betweenness','pagerank','all'], default='all', required=False)
 
 # define the input options for the filtered node and filtered edge calls.
 class NodeAndEdgeFilteredQuerySerializer(serializers.Serializer):

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,11 @@ setup(
         'gunicorn',
         # Development-only
         'django-debug-toolbar',
+        # add for graph algorithms
+        'arrow',
+        'networkx',
+        'numpy',
+        'scipy',
     ],
     extras_require={'dev': ['ipython', 'tox']},
 )

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,8 @@ setup(
         'networkx',
         'numpy',
         'scipy',
+        # installing older pandas to work with numpy version installed
+        'pandas~=1.2.2',
     ],
     extras_require={'dev': ['ipython', 'tox']},
 )


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #  N/A

### Give a longer description of what this PR addresses and why it's needed

- This PR includes support for new API endpoints:  nodes_stats, nodes_filtered, edges_filtered.
- The first endpoint provides server-based calculation for betweenness centrality, node centrality, pagerank, and in/out node degree
- The second and third endoint enable extraction of a subgraph from a large graph by specifying a minimal threshold for in or out degrees of nodes to be included.  Current behavior returns some unconnected nodes.  Will look into this... 

### Provide pictures/videos of the behavior before and after these changes (optional)


### Are there any additional TODOs before this PR is ready to go?
Further testing by Jack. 

TODOs:
- [ ] Determine why `nodes_filtered` endpoint can return disconnected nodes