### PR TITLE
Add DEFAULT_AUTO_FIELD to silence warning on the command line

### DIFF
--- a/multinet/settings.py
+++ b/multinet/settings.py
@@ -13,6 +13,8 @@ from composed_configuration import (
 from configurations import values
 
 
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+
 class MultinetMixin(ConfigMixin):
     WSGI_APPLICATION = 'multinet.wsgi.application'
     ROOT_URLCONF = 'multinet.urls'


### PR DESCRIPTION
### Does this PR close any open issues?
No

### Give a longer description of what this PR addresses and why it's needed
We were getting a bunch of warnings that look like:

```
...
api.Upload: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
        HINT: Configure the DEFAULT_AUTO_FIELD setting or the ApiConfig.default_auto_field attribute to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.
api.Workspace: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
        HINT: Configure the DEFAULT_AUTO_FIELD setting or the ApiConfig.default_auto_field attribute to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.
...
```

Following the advice [here](https://dev.to/weplayinternet/upgrading-to-django-3-2-and-fixing-defaultautofield-warnings-518n), I chose to set it to `AutoField` so we don't have more migrations to run.

### Provide pictures/videos of the behavior before and after these changes (optional)
N/A

### Are there any additional TODOs before this PR is ready to go?
No