### PR TITLE
Add a delimiter field to the csv upload for user specification

### DIFF
--- a/multinet/api/tasks/upload/csv.py
+++ b/multinet/api/tasks/upload/csv.py
@@ -38,7 +38,7 @@ def process_row(row: Dict[str, Any], cols: Dict[str, TableTypeAnnotation.Type]) 
 
 @shared_task(base=ProcessUploadTask)
 def process_csv(
-    task_id: int, table_name: str, edge: bool, columns: Dict[str, TableTypeAnnotation.Type], delimiter: str
+    task_id: int, table_name: str, edge: bool, columns: Dict[str, TableTypeAnnotation.Type], delimiter: str, quotechar: str
 ) -> None:
     upload: Upload = Upload.objects.get(id=task_id)
 
@@ -48,6 +48,7 @@ def process_csv(
         csv_rows = list(csv.DictReader(
             StringIO(blob_file.read().decode('utf-8')),
             delimiter=delimiter,
+            quotechar=quotechar,
         ))
 
     # Cast entries in each row to appropriate type, if necessary

--- a/multinet/api/tasks/upload/csv.py
+++ b/multinet/api/tasks/upload/csv.py
@@ -38,14 +38,17 @@ def process_row(row: Dict[str, Any], cols: Dict[str, TableTypeAnnotation.Type]) 
 
 @shared_task(base=ProcessUploadTask)
 def process_csv(
-    task_id: int, table_name: str, edge: bool, columns: Dict[str, TableTypeAnnotation.Type]
+    task_id: int, table_name: str, edge: bool, columns: Dict[str, TableTypeAnnotation.Type], delimiter: str
 ) -> None:
     upload: Upload = Upload.objects.get(id=task_id)
 
     # Download data from S3/MinIO
     with upload.blob as blob_file:
         blob_file: BinaryIO = blob_file
-        csv_rows = list(csv.DictReader(StringIO(blob_file.read().decode('utf-8'))))
+        csv_rows = list(csv.DictReader(
+            StringIO(blob_file.read().decode('utf-8')),
+            delimiter=delimiter,
+        ))
 
     # Cast entries in each row to appropriate type, if necessary
     for i, row in enumerate(csv_rows):

--- a/multinet/api/tasks/upload/csv.py
+++ b/multinet/api/tasks/upload/csv.py
@@ -38,18 +38,25 @@ def process_row(row: Dict[str, Any], cols: Dict[str, TableTypeAnnotation.Type]) 
 
 @shared_task(base=ProcessUploadTask)
 def process_csv(
-    task_id: int, table_name: str, edge: bool, columns: Dict[str, TableTypeAnnotation.Type], delimiter: str, quotechar: str
+    task_id: int,
+    table_name: str,
+    edge: bool,
+    columns: Dict[str, TableTypeAnnotation.Type],
+    delimiter: str,
+    quotechar: str,
 ) -> None:
     upload: Upload = Upload.objects.get(id=task_id)
 
     # Download data from S3/MinIO
     with upload.blob as blob_file:
         blob_file: BinaryIO = blob_file
-        csv_rows = list(csv.DictReader(
-            StringIO(blob_file.read().decode('utf-8')),
-            delimiter=delimiter,
-            quotechar=quotechar,
-        ))
+        csv_rows = list(
+            csv.DictReader(
+                StringIO(blob_file.read().decode('utf-8')),
+                delimiter=delimiter,
+                quotechar=quotechar,
+            )
+        )
 
     # Cast entries in each row to appropriate type, if necessary
     for i, row in enumerate(csv_rows):

--- a/multinet/api/tests/test_upload_csv.py
+++ b/multinet/api/tests/test_upload_csv.py
@@ -108,6 +108,8 @@ def test_create_upload_model_invalid_columns(
             'edge': False,
             'table_name': 'table',
             'columns': {'foo': 'invalid'},
+            'delimiter': ',',
+            'quotechar': '\"',
         },
         format='json',
     )
@@ -166,6 +168,8 @@ def test_create_upload_model_invalid_field_value(
             'field_value': 'field_value',
             'edge': False,
             'table_name': 'table',
+            'delimiter': ',',
+            'quotechar': '\"',
         },
         format='json',
     )

--- a/multinet/api/tests/test_upload_csv.py
+++ b/multinet/api/tests/test_upload_csv.py
@@ -32,8 +32,6 @@ def local_csv_upload(path: pathlib.Path, workspace, user) -> Upload:
         user=user,
         blob=file,
         data_type=Upload.DataType.CSV,
-        delimiter=",",
-        quotechar="\"",
     )
 
 
@@ -63,6 +61,8 @@ def airports_csv(
                 'timezone': 'number',
                 'year built': 'number',
             },
+            'delimiter': ',',
+            'quotechar': '\"',
         },
         format='json',
     )

--- a/multinet/api/tests/test_upload_csv.py
+++ b/multinet/api/tests/test_upload_csv.py
@@ -32,6 +32,8 @@ def local_csv_upload(path: pathlib.Path, workspace, user) -> Upload:
         user=user,
         blob=file,
         data_type=Upload.DataType.CSV,
+        delimiter=",",
+        quotechar="\"",
     )
 
 

--- a/multinet/api/tests/test_upload_csv.py
+++ b/multinet/api/tests/test_upload_csv.py
@@ -119,6 +119,64 @@ def test_create_upload_model_invalid_columns(
 
 
 @pytest.mark.django_db
+def test_create_upload_model_missing_delimiter(
+    workspace: Workspace, user: User, authenticated_api_client
+):
+    workspace.set_user_permission(user, WorkspaceRoleChoice.WRITER)
+    r: Response = authenticated_api_client.post(
+        f'/api/workspaces/{workspace.name}/uploads/csv/',
+        {
+            # Not an issue to specify invalid field_value, as that's checked after columns,
+            # so the request will return before that is checked
+            'field_value': 'field_value',
+            'edge': False,
+            'table_name': 'table',
+            'columns': {
+                'latitude': 'number',
+                'longitude': 'number',
+                'altitude': 'number',
+                'timezone': 'number',
+                'year built': 'number',
+            },
+            'quotechar': '\"',
+        },
+        format='json',
+    )
+
+    assert r.status_code == 400
+    assert r.json() == {'delimiter': ['This field is required.']}
+
+
+@pytest.mark.django_db
+def test_create_upload_model_missing_quotechar(
+    workspace: Workspace, user: User, authenticated_api_client
+):
+    workspace.set_user_permission(user, WorkspaceRoleChoice.WRITER)
+    r: Response = authenticated_api_client.post(
+        f'/api/workspaces/{workspace.name}/uploads/csv/',
+        {
+            # Not an issue to specify invalid field_value, as that's checked after columns,
+            # so the request will return before that is checked
+            'field_value': 'field_value',
+            'edge': False,
+            'table_name': 'table',
+            'columns': {
+                'latitude': 'number',
+                'longitude': 'number',
+                'altitude': 'number',
+                'timezone': 'number',
+                'year built': 'number',
+            },
+            'delimiter': ',',
+        },
+        format='json',
+    )
+
+    assert r.status_code == 400
+    assert r.json() == {'quotechar': ['This field is required.']}
+
+
+@pytest.mark.django_db
 @pytest.mark.parametrize('permission,status_code', [(None, 404), (WorkspaceRoleChoice.READER, 403)])
 def test_create_upload_model_csv_invalid_permissions(
     workspace: Workspace,

--- a/multinet/api/views/serializers.py
+++ b/multinet/api/views/serializers.py
@@ -255,6 +255,7 @@ class CSVUploadCreateSerializer(UploadCreateSerializer):
         child=serializers.ChoiceField(choices=TableTypeAnnotation.Type.choices),
         default=dict,
     )
+    delimiter = serializers.CharField()
 
 
 class D3JSONUploadCreateSerializer(UploadCreateSerializer):

--- a/multinet/api/views/serializers.py
+++ b/multinet/api/views/serializers.py
@@ -256,6 +256,7 @@ class CSVUploadCreateSerializer(UploadCreateSerializer):
         default=dict,
     )
     delimiter = serializers.CharField()
+    quotechar = serializers.CharField()
 
 
 class D3JSONUploadCreateSerializer(UploadCreateSerializer):

--- a/multinet/api/views/upload.py
+++ b/multinet/api/views/upload.py
@@ -91,6 +91,7 @@ class UploadViewSet(WorkspaceChildMixin, ReadOnlyModelViewSet):
             edge=serializer.validated_data['edge'],
             columns=serializer.validated_data['columns'],
             delimiter=serializer.validated_data['delimiter'],
+            quotechar=serializer.validated_data['quotechar'],
         )
 
         return Response(UploadReturnSerializer(upload).data, status=status.HTTP_200_OK)

--- a/multinet/api/views/upload.py
+++ b/multinet/api/views/upload.py
@@ -90,6 +90,7 @@ class UploadViewSet(WorkspaceChildMixin, ReadOnlyModelViewSet):
             table_name=table_name,
             edge=serializer.validated_data['edge'],
             columns=serializer.validated_data['columns'],
+            delimiter=serializer.validated_data['delimiter'],
         )
 
         return Response(UploadReturnSerializer(upload).data, status=status.HTTP_200_OK)


### PR DESCRIPTION
### Does this PR close any open issues?
There's no issue in the api for this, it's a frontend issue.

### Give a longer description of what this PR addresses and why it's needed
This allows for a user/frontend specified delimiter for processing csv files. This is important, since csvs are only loosely standardized. With the frontend, we can now support `,`,`;`,`\t`, etc.

### Provide pictures/videos of the behavior before and after these changes (optional)
N/A

### Are there any additional TODOs before this PR is ready to go?
No