### PR TITLE
Make CSV uploader insert in batches

### DIFF
--- a/multinet/api/tasks/upload/csv.py
+++ b/multinet/api/tasks/upload/csv.py
@@ -80,10 +80,9 @@ def process_csv(
             if len(processed_rows) == 100000:
                 table.put_rows(processed_rows)
                 processed_rows = []
-        
+
         # Put remaining rows
         table.put_rows(processed_rows)
-
 
 
 def maybe_insert_join_statement(query: str, bind_vars: Dict, table_dict: Dict) -> Tuple[str, Dict]:

--- a/multinet/api/tasks/upload/csv.py
+++ b/multinet/api/tasks/upload/csv.py
@@ -65,12 +65,10 @@ def process_csv(
     # Download data from S3/MinIO
     with upload.blob as blob_file:
         blob_file: BinaryIO = blob_file
-        csv_rows = list(
-            csv.DictReader(
-                StringIO(blob_file.read().decode('utf-8')),
-                delimiter=delimiter,
-                quotechar=quotechar,
-            )
+        csv_reader = csv.DictReader(
+            StringIO(blob_file.read().decode('utf-8')),
+            delimiter=delimiter,
+            quotechar=quotechar,
         )
 
         # Cast entries in each row to appropriate type, if necessary

--- a/multinet/api/tasks/upload/csv.py
+++ b/multinet/api/tasks/upload/csv.py
@@ -47,21 +47,6 @@ def process_csv(
 ) -> None:
     upload: Upload = Upload.objects.get(id=task_id)
 
-    # Download data from S3/MinIO
-    with upload.blob as blob_file:
-        blob_file: BinaryIO = blob_file
-        csv_rows = list(
-            csv.DictReader(
-                StringIO(blob_file.read().decode('utf-8')),
-                delimiter=delimiter,
-                quotechar=quotechar,
-            )
-        )
-
-    # Cast entries in each row to appropriate type, if necessary
-    for i, row in enumerate(csv_rows):
-        csv_rows[i] = process_row(row, columns)
-
     # Create new table
     table: Table = Table.objects.create(
         name=table_name,
@@ -77,8 +62,30 @@ def process_csv(
         ]
     )
 
-    # Insert rows
-    table.put_rows(csv_rows)
+    # Download data from S3/MinIO
+    with upload.blob as blob_file:
+        blob_file: BinaryIO = blob_file
+        csv_rows = list(
+            csv.DictReader(
+                StringIO(blob_file.read().decode('utf-8')),
+                delimiter=delimiter,
+                quotechar=quotechar,
+            )
+        )
+
+        # Cast entries in each row to appropriate type, if necessary
+        processed_rows = []
+        for row in csv_reader:
+            processed_rows.append(process_row(row, columns))
+
+            # Insert rows
+            if len(processed_rows) == 100000:
+                table.put_rows(processed_rows)
+                processed_rows = []
+        
+        # Put remaining rows
+        table.put_rows(processed_rows)
+
 
 
 def maybe_insert_join_statement(query: str, bind_vars: Dict, table_dict: Dict) -> Tuple[str, Dict]:


### PR DESCRIPTION
### Does this PR close any open issues?
Depends #145

### Give a longer description of what this PR addresses and why it's needed
This batches up the inserts for uploading large tables. With this code, I managed to upload ~6.5 million rows (at a csv file size of 2.5 GB) without running out of memory.

I decided to make this PR depend on #145, since it's modifying similar code. The final commit is the only new change in this branch

### Provide pictures/videos of the behavior before and after these changes (optional)
N/A

### Are there any additional TODOs before this PR is ready to go?
