### PR TITLE
removed default whitespace trim for delimiter serializer

### DIFF
--- a/multinet/api/views/serializers.py
+++ b/multinet/api/views/serializers.py
@@ -255,7 +255,7 @@ class CSVUploadCreateSerializer(UploadCreateSerializer):
         child=serializers.ChoiceField(choices=TableTypeAnnotation.Type.choices),
         default=dict,
     )
-    delimiter = serializers.CharField()
+    delimiter = serializers.CharField(trim_whitespace=False)
     quotechar = serializers.CharField()
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -59,6 +59,7 @@ deps =
     pytest-django
     pytest-factoryboy
     pytest-mock
+allowlist_externals=./manage.py
 commands_pre =
     ./manage.py createarangoreadonlyuser
 commands =


### PR DESCRIPTION
### Does this PR close any open issues?
None open but allows for whitespace delimiters in CSV

### Give a longer description of what this PR addresses and why it's needed
This PR adds the ability to use a whitespace delimiter for CSV files.