### PR TITLE
Redirect login and signup to google login, disabling password signups

### DIFF
--- a/multinet/urls.py
+++ b/multinet/urls.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.contrib import admin
 from django.urls import include, path
+from django.views.generic import RedirectView
 from drf_yasg import openapi
 from drf_yasg.views import get_schema_view
 from rest_framework import permissions
@@ -65,6 +66,9 @@ schema_view = get_schema_view(
 )
 
 urlpatterns = [
+    # Override allauth login and signup to use Google OAuth2
+    path('accounts/login/', RedirectView.as_view(url='/accounts/google/login/')),
+    path('accounts/signup/', RedirectView.as_view(url='/accounts/google/login/')),
     path('accounts/', include('allauth.urls')),
     path('oauth/', include('oauth2_provider.urls', namespace='oauth2_provider')),
     path('admin/', admin.site.urls),


### PR DESCRIPTION
### Does this PR close any open issues?
No

### Give a longer description of what this PR addresses and why it's needed
Using advice from https://github.com/pennersr/django-allauth/issues/345, I redirected a couple of the routes (`signup` and `login`) that are used by the allauth package to the google login route. This means we won't ever offer password logins to users.

### Provide pictures/videos of the behavior before and after these changes (optional)
![image](https://github.com/multinet-app/multinet-api/assets/36867477/ed4a9bd3-9e09-4410-8299-b77cdc59adc6)

### Are there any additional TODOs before this PR is ready to go?
No