### PR TITLE
Add default field for alttxt level serializer

### DIFF
--- a/multinet/api/views/alttxt.py
+++ b/multinet/api/views/alttxt.py
@@ -16,8 +16,8 @@ from rest_framework.views import APIView
 
 class AlttxtSerializer(serializers.Serializer):
     verbosity = serializers.ChoiceField(choices=Verbosity.list())
-    level = serializers.ChoiceField(choices=Level.list())
     explain = serializers.ChoiceField(choices=Explanation.list())
+    level = serializers.ChoiceField(choices=Level.list(), default='default')
     title = serializers.CharField(max_length=200, default='')
     data = serializers.FileField(allow_empty_file=False)
 


### PR DESCRIPTION
### Does this PR close any open issues?
Closes none

### Give a longer description of what this PR addresses and why it's needed
This PR updates the alttext view so that level is an optional parameter with a default value `default`. This is necessary because the newest alttext-gen version 0.1.11 (#165) uses the `default` value to combine levels when generating alttext.

### Provide pictures/videos of the behavior before and after these changes (optional)


### Are there any additional TODOs before this PR is ready to go?
TODOs:
- [ NA ] Update relevant documentation (don't think there is any)