### PR TITLE
Update row processing string assumption

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   django:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   postgres:
     image: postgres:15
@@ -11,7 +10,7 @@ services:
       - pg_data:/var/lib/postgresql/data
 
   arangodb:
-    image: arangodb:3.8
+    image: arangodb:3.10
     ports:
       - "${ARANGO_PORT:-8529}:8529"
     environment:

--- a/multinet/api/tasks/upload/process_single_table.py
+++ b/multinet/api/tasks/upload/process_single_table.py
@@ -74,7 +74,7 @@ def process_row(
             continue
 
         # Get the value of the column
-        entry = new_row.get(col_key)
+        entry = str(new_row.get(col_key))
 
         # If null, skip
         if entry is None:

--- a/multinet/api/tasks/upload/process_single_table.py
+++ b/multinet/api/tasks/upload/process_single_table.py
@@ -74,7 +74,7 @@ def process_row(
             continue
 
         # Get the value of the column
-        entry = str(new_row.get(col_key))
+        entry = new_row.get(col_key)
 
         # If null, skip
         if entry is None:

--- a/multinet/api/tasks/upload/utils.py
+++ b/multinet/api/tasks/upload/utils.py
@@ -10,8 +10,9 @@ from multinet.api.models import TableTypeAnnotation
 logger = get_task_logger(__name__)
 
 
-def str_to_bool(entry: str) -> bool:
+def str_to_bool(entry: any) -> bool:
     """Try to determine base format of boolean so it can be converted properly."""
+    entry = str(entry)
 
     def from_int(x: str) -> Optional[bool]:
         if x == '0' or x == '1':
@@ -43,8 +44,9 @@ def str_to_bool(entry: str) -> bool:
     return cast_col_entry(entry)
 
 
-def str_to_datestr(entry: str) -> str:
+def str_to_datestr(entry: any) -> str:
     """Try to read a date as an ISO 8601 string or unix timestamp."""
+    entry = str(entry)
     try:
         # Raises ValueError is entry is not a float/int
         # Raises ValueError if the number is out of range
@@ -54,8 +56,9 @@ def str_to_datestr(entry: str) -> str:
         return dateutilparser.parse(entry).isoformat()
 
 
-def str_to_number(entry: str) -> Union[int, float]:
+def str_to_number(entry: any) -> Union[int, float]:
     """Try to read a number from a given string."""
+    entry = str(entry)
     try:
         return int(entry)
     except ValueError:

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'celery',
+        'cryptography',
         'django~=3.2.11',
         'django-admin-display',
         'django-allauth>=0.57.0',


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #173 

### Give a longer description of what this PR addresses and why it's needed
This PR adds a string cast when pulling the column value during table upload. This is because the types are loading dynamically (ie: float, int, etc) but the processing functions are assuming string types for any input. This means that types such as float will be cast to int in the `str_to_number` function, without raising any error.

One option is to modify the `str_to_number` function, but this is not inline with the behavior of all other types.

Dataset upload for movies dataset tested locally and working as expected.

### Provide pictures/videos of the behavior before and after these changes (optional)
See #173 screenshots

### Are there any additional TODOs before this PR is ready to go?
TODOs:
- [X] Update relevant documentation: none needed