### PR TITLE
Bump upset-alttxt to 0.2.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
         'drf-yasg',
         'more-itertools',
         'python-arango',
-        'upset-alttxt>=0.2.7',
+        'upset-alttxt>=0.2.8',
         # Production-only
         'gunicorn',
         # Development-only


### PR DESCRIPTION
### Does this PR close any open issues?
Closes none

### Give a longer description of what this PR addresses and why it's needed
Bumps alt-txt package version to [v0.2.8](https://github.com/visdesignlab/upset-alt-txt-gen/releases/tag/v0.2.8)

### Provide pictures/videos of the behavior before and after these changes (optional)


### Are there any additional TODOs before this PR is ready to go?
TODOs:
- [ ] Update relevant documentation
- [ ] ...