### PR TITLE
Update workspace fork to include selective copy

### DIFF
--- a/multinet/api/views/workspace.py
+++ b/multinet/api/views/workspace.py
@@ -117,7 +117,7 @@ class WorkspaceViewSet(ReadOnlyModelViewSet):
         These should be comma-separated lists of table and network names.
 
         Example:
-        /api/workspace/{id}/fork?tables=upsettablename,upsettablename2?networks=networkname
+        /api/workspaces/miserables/fork/?tables=characters%2Crelationships&networks=miserables
 
         The new workspace will be private by default and the name will be:
         'Fork of {original workspace name}'


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #181 

### Give a longer description of what this PR addresses and why it's needed
Changes the fork call to only include tables/networks that are explicitly defined via query parameters.

Parameters:
`tables`: comma-separated list of table names to copy
`networks`: comma-separated list of network names to copy

Example use:
`/api/workspaces/miserables/fork/?tables=characters%2Crelationships&networks=miserables`
Copies all networks and tables from within the Miserables workspace

TODO:
[ ] - Update multinet frontend API call to include hydrated query params
